### PR TITLE
Allow excluding specified edges for schnet

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -1,12 +1,12 @@
 Datasets
 ========
 
-`mlcg.datasets` contains a template `InMemoryDataset` for CLN025, a 10 amino acid long mini protein that shows prototypical folding and unfolding behavior. The `ChignolinDataset` class illustrates how a general dataset can be downloaded, unpacked/organized, transformed/processed, and collated for training models. `Here <https://pytorch-geometric.readthedocs.io/en/latest/notes/create_dataset.html>`_, users can find more information on implementing custom datasets.
+``mlcg.datasets`` contains a template ``InMemoryDataset`` for CLN025, a 10 amino acid long mini protein that shows prototypical folding and unfolding behavior. The ``ChignolinDataset`` class illustrates how a general dataset can be downloaded, unpacked/organized, transformed/processed, and collated for training models. `Here <https://pytorch-geometric.readthedocs.io/en/latest/notes/create_dataset.html>`_, users can find more information on implementing custom datasets.
 
 Chignolin Dataset
 -----------------
 
-Dataset of 3744 individual all-atom trajectories simulated using [ACEMD]_ using the adaptive sampling strategy described in [AdaptiveStrategy]_ . All trajectories were simulated at 350K with [CHARM22Star]_ in a cubic box of 40 angstroms :sup:`3` with 1881 TIP3P water molecules and two Na :sup:`+` ions using a Langevin integrator with an integration timestep of 4 fs, a damping constant of 0.1 :sup:`-1` ps, heavy-hydrogen constraints, and a PME cutoff of 9 angstroms and a PME mesh grid of 1 angstrom. The total aggregate simulation time is 187.2 us. 
+Dataset of 3744 individual all-atom trajectories simulated using [ACEMD]_ using the adaptive sampling strategy described in [AdaptiveStrategy]_ . All trajectories were simulated at 350K with [CHARM22Star]_ in a cubic box of 40 angstroms :sup:``3`` with 1881 TIP3P water molecules and two Na :sup:``+`` ions using a Langevin integrator with an integration timestep of 4 fs, a damping constant of 0.1 :sup:``-1`` ps, heavy-hydrogen constraints, and a PME cutoff of 9 angstroms and a PME mesh grid of 1 angstrom. The total aggregate simulation time is 187.2 us. 
 
 .. autoclass:: mlcg.datasets.chignolin.ChignolinDataset
 
@@ -18,6 +18,173 @@ Dataset of a single 1M step trajectory of alanine dipeptide in explicit water. T
 
 Custom H5 Dataset
 -----------------
+
 Users may assemble their own curated dataset using an H5 format. This allows for the possiblity of training on multiple types of molecules or data from different system conditiions.
 
+Inroduction
+^^^^^^^^^^^
+
+HDF5 format benefits the dataset management for mlcg when training/validation involves multiple molecules of vastly different lengths and when parallelization is used.
+The main features are:
+
+1. The internal structure mimics the hierarchy of the dataset itself, such that we don't have to replicate it on filesystem.
+2. we don't have to actively open all files in the process
+3. we can transparently load only the necessary part of the dataset to the memory
+
+This file contains the python data structures for handling the HDF5 file and its content, i.e., the coordinates, forces and embedding vectors for multiple CG molecules.
+An example HDF5 file structure and correponding class types after loading:
+
+.. code-block::
+
+        / (HDF-group, => ``H5Dataset._h5_root``)
+        ├── OPEP (HDF-group =(part, according to "partition_options")=> ``Metaset`` in a ``Partition``)
+        │   ├── opep_0000 (HDF-group, => ``MolData``)
+        │   │   ├── attrs (HDF-attributes of the molecule "/OPEP/opep_0000")
+        │   │   │   ├── cg_embeds (a 1-d numpy.int array)
+        │   │   │   ├── N_frames (int, number of frames = size of cg_coords on axis 0)
+        │   │   │   ... (optional, e.g., cg_exc_pairs cg_top, cg_pdb, etc that corrsponds to the molecule)
+        │   │   ├── cg_coords (HDF-dataset of the molecule "/OPEP/opep_0000", 3-d numpy.float32 array)
+        │   │   └── cg(_delta)_forces (HDF-dataset of the molecule "/OPEP/opep_0000", 3-d numpy.float32 array)
+        │   ... (other molecules in "/OPEP")
+        ├── CATH (HDF-group ="partition_options"=> ``Metaset`` in a ``Partition``)
+        ...
+
+Basic bricks: ``MolData`` and ``MetaSet``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Data structure ``MolData`` is the basic brick of the dataset.
+It holds embeds, coords and forces of certain number of frames for a single molecule.
+.sub_sample: method for performing indexing on the frames.
+
+
+.. autoclass:: mlcg.datasets.MolData
+
+
+Data strcuture ``Metaset`` holds multiple molecules and joins their frame indices together.
+One can access frames of underlying MolData objects with a continuous index.
+The idea is that the molecules in a ``Metaset`` have similar numbers of CG beads, such that the sample requires similar processing time when passing through a neural network.
+When this rule is enforced, it will allow automatic balancing of batch composition during training and validation.
+
+
+
+* ``.create_from_hdf5_group``: initiate a Metaset by loading data from given HDF-group.mol_list, detailed_indices, hdf_key_mapping, stride and parallel can control which subset is loaded to the Metaset (details see the description of "H5Dataset")
+* ``.trim_down_to``: drop frames of underlying for obtaining a subset with desired number of frames. The indices of frames to be dropped are controlled by a random number generator. When the parameter "random_seed" and the MolData order and number of frames are the same, the frames to be dropped will be reproducible.
+* ``len() (__len__)``: return total number of samples
+* ``[] (__get_item__)``: infer the molecule and get the corresponding frame according to the given unified index. Return value is grouped by an ``AtomicData`` object.
+
+.. autoclass:: mlcg.datasets.MetaSet
+
+Train test split: ``Partition``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Data structure ``Partition`` can hold multiple Metaset for training and validation purposes.
+Its main function is to automatic adjust (subsample) the Metaset(s) and the underlying MolData to form a balanced data source, from which a certain number of batches can be drawn. Each batch will contain a pre-given number of samples from each Metaset.
+One or several ``Partition``s can be created to load part of the same HDF5 file into the memory.
+The exact content inside a ``Partition`` object is controlled by the ``partition_options`` as a parameter for initializing a ``H5Dataset``.
+
+.. autoclass:: mlcg.datasets.Partition
+
+
+Full Dataset: ``H5Dataset``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+Data strcuture ``H5Dataset`` opens a HDF5 file and establish the partitions.
+``partition_options`` describe what partitions to create and what content to load into them. (Detailed description and examples are as followed.)
+``loading_options`` mainly deal with the HDF key mapping (which datasets/attributes corresponds to the coordinates, forces and embeddings) as well as (optionally) the information for correctly split the dataset in a parallel training/validation.
+
+An example "partition_options" (as a Python Mappable (e.g., dict)):
+
+.. code-block::
+
+        {
+                "train": {
+                        "metasets": {
+                                "OPEP": {
+                                        "molecules": [
+                                                "opep_0000",
+                                                "opep_0001",
+                                                ...
+                                        ],
+                                        "stride": 1, # optional, default 1
+                                        "detailed_indices": {
+                        # optional, providing the indices of frames to work with (before striding and splitting for parallel processes).
+                                                # optional,
+                            "opep_0000":
+                                val_ratio: 0.1
+                                test_ratio: 0.1
+                                seed: 12345
+                            "opep_0001":
+                                val_ratio: 0.1
+                                test_ratio: 0.1
+                                seed: 12345
+                            "filename": ./splits
+
+                        # If detailed_indices are not provided for a given molecule, then it is equivalent to np.arange(N_frames)
+                                                    "opep_0000": [1, 3, 5, 7, 9, ...],
+
+
+                                        },
+                                },
+                                "CATH": {
+                                        "molecules": [
+                                                "cath_1b43A02",
+                                                ...
+                                        ],
+                                        "stride": 1, # optional
+                                        "detailed_indices": {}, # optional
+                                }
+                        },
+                        "batch_size": {
+                                # each batch will contain 24 samples from
+                                # The two metasets will be trimmed down according to this ratio
+                                # so optimally it should be proportional to the ratio of numbers of frames in the metasets.
+                                "OPEP": 24,
+                                "CATH": 6,
+                        },
+                        "subsample_random_seed": 42, # optional, default 42. Random seed for trimming down the frames.
+                        "max_epoch_samples": None, # optional, default None. For setting a desired dataset size.
+                        # Works by subsampling the dataset after it is loaded with the given stride.
+                },
+                "val": { # similar
+                }
+        }
+
+An example "loading_options" (as a Python Mappable (e.g., dict)):
+
+.. code-block::
+
+        {
+                "hdf_key_mapping": {
+                        # keys for reading CG data from HDF5 groups
+                        "embeds": "attrs:cg_embeds",
+                        "coords": "cg_coords",
+                        "forces": "cg_delta_forces",
+                },
+                "parallel": { # optional, default rank=0 and world_size=1 (single process).
+                        # For split the dataset evenly and load only the necessary parts to each process in a parallelized train/val setup
+                        "rank": 0, # which process is this
+                        "world_size": 1, # how many processes are there
+                }
+        }
+
 .. autoclass:: mlcg.datasets.H5Dataset
+
+
+Loading into PyTorch: ``H5PartitionDataLoader``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Class ``H5PartitionDataLoader`` mimics the pytorch data loader and can generate training/validation batches with fixed proportion of samples from several Metasets in a Partition.
+The proportion and batch size is defined when the partition is initialized.
+When the molecules in each Metaset have similar embedding vector lengths, the processing of output batches will require a more or less fixed size of VRAM on GPU, which can benefit the
+
+Note:
+1. Usually in a train-val split, each molecule goes to either the train or the test partition.
+     In some special cases (e.g., non-transferable training) one molecule can be part of both partitions.
+     In this situation, "detailed_indices" can be set to assign the corresponding frames to the desired partitions.
+In addition one can pass in detailed_indices as a dictionary to split frames based on training/test (see partition_options example above)
+
+.. autoclass:: mlcg.datasets.H5PartitionDataLoader
+
+
+

--- a/examples/h5_pl/train_h5_1_10_exclusion.yaml
+++ b/examples/h5_pl/train_h5_1_10_exclusion.yaml
@@ -121,4 +121,4 @@ data:
       coords: cg_coords
       forces: cg_delta_forces
       exclusion_pairs: attrs:cg_exc_pairs
-  exclude_bonded_pairs: true
+  exclude_listed_pairs: true

--- a/examples/h5_pl/train_h5_1_10_exclusion.yaml
+++ b/examples/h5_pl/train_h5_1_10_exclusion.yaml
@@ -1,0 +1,124 @@
+# example training script
+# check the following options:
+#   trainer
+#       default_root_dir
+#       max_epochs
+#       devices
+#       enable_progress_bar
+#   optimizer.init_args.lr
+#   data
+#       h5_file_path
+#       partition_options
+seed_everything: 19384
+# define the training
+trainer:
+  # Work directory for the session
+  default_root_dir: ./h5_1_10
+  max_epochs: 1
+  max_time: null
+  resume_from_checkpoint: null
+  profiler: null
+
+  accelerator: 'gpu'
+  strategy: 'ddp'
+  devices: 1 # change this to the number of GPUs to see how parallelization works on a cluster node
+  precision: 32
+  logger:
+    - class_path: pytorch_lightning.loggers.TensorBoardLogger
+      init_args:
+        save_dir: default_root_dir
+        name: tensorboard
+        version: ''
+  benchmark: false
+  enable_checkpointing: true
+  callbacks:
+    - class_path: pytorch_lightning.callbacks.EarlyStopping
+      init_args:
+        monitor: 'validation_loss'
+        patience: 5
+    - class_path: pytorch_lightning.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: epoch
+        log_momentum: false
+    - class_path: pytorch_lightning.callbacks.model_checkpoint.ModelCheckpoint
+      init_args:
+        dirpath: default_root_dir
+        monitor: validation_loss
+        save_top_k: -1
+        every_n_epochs: 1
+        filename: '{epoch}-{validation_loss:.4f}'
+        save_last: true
+  log_every_n_steps: 500
+  gradient_clip_val: 0
+  gradient_clip_algorithm: norm
+  log_gpu_memory: null
+  track_grad_norm: -1
+  check_val_every_n_epoch: 1
+  fast_dev_run: false
+  accumulate_grad_batches: 1 # you can change this to enable a even higher effective batch size
+  enable_model_summary: false
+  deterministic: false
+  auto_lr_find: false
+  detect_anomaly: false # setting this to true enables detection of NaN after every small-batch update, but will slow down the training by 30%~50%
+  replace_sampler_ddp: false # see https://pytorch-lightning.readthedocs.io/en/latest/common/trainer.html#replace-sampler-ddp for details
+  # enable_progress_bar: false # uncomment this in production (e.g., when redirecting the stdout to a file), otherwise it will generate huge a huge log file and harm the disk
+model:
+  loss:
+    class_path: mlcg.nn.Loss
+    init_args:
+      losses:
+        - class_path: mlcg.nn.ForceMSE
+          init_args:
+            force_kwd: forces
+  model:
+    class_path: mlcg.nn.GradientsOut
+    init_args:
+      targets: forces
+      model:
+        class_path: mlcg.nn.schnet.StandardSchNet
+        init_args:
+          hidden_channels: 128
+          embedding_size: 25
+          num_filters: 128
+          num_interactions: 5
+          output_hidden_layer_widths:
+            - 128
+          activation:
+            class_path: torch.nn.Tanh
+            init_args: {}
+          max_num_neighbors: 100
+          aggr: "add"
+          cutoff:
+            class_path: mlcg.nn.CosineCutoff
+            init_args:
+              cutoff_lower: 0
+              cutoff_upper: 20
+          rbf_layer:
+            class_path: mlcg.nn.ExpNormalBasis
+            init_args:
+              cutoff: 20
+              num_rbf: 128
+              trainable: false
+  monitor: validation_loss
+  step_frequency: 1
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 0.0008
+    weight_decay: 0
+lr_scheduler:
+  class_path: torch.optim.lr_scheduler.ReduceLROnPlateau
+  init_args:
+    factor: 0.5
+    patience: 3
+    min_lr: 0.000001
+data:
+  h5_file_path: /import/a12/users/nickc/mlcg_delta_datasets/dihedral_1_6_res_exclusion/combined_dihedral_1_6_res_exclusion.h5 # point to your actual dataset location
+  partition_options: ./partition_settings.yaml
+  loading_options:
+    hdf_key_mapping:
+      embeds: attrs:cg_embeds
+      coords: cg_coords
+      forces: cg_delta_forces
+      exclusion_pairs: attrs:cg_exc_pairs
+  exclude_bonded_pairs: true

--- a/mlcg/datasets/__init__.py
+++ b/mlcg/datasets/__init__.py
@@ -1,5 +1,8 @@
 from .chignolin import ChignolinDataset
 from .h5_dataset import (
+    MolData,
+    MetaSet,
+    Partition,
     H5PartitionDataLoader,
     H5MetasetDataLoader,
     H5Dataset,

--- a/mlcg/datasets/h5_dataset.py
+++ b/mlcg/datasets/h5_dataset.py
@@ -1,142 +1,3 @@
-r"""Python classes for processing data stored in HDF5 format.
-
-HDF5 format benefits the dataset management for mlcg when training/validation involves multiple molecules of vastly different lengths and when parallelization is used.
-The main features are:
-1. The internal structure mimics the hierarchy of the dataset itself, such that we don't have to replicate it on filesystem.
-2. we don't have to actively open all files in the process
-3. we can transparently load only the necessary part of the dataset to the memory
-
-This file contains the python data structures for handling the HDF5 file and its content, i.e., the coordinates, forces and embedding vectors for multiple CG molecules.
-An example HDF5 file structure and correponding class types after loading:
-
-.. code-block::
-
-        / (HDF-group, => `H5Dataset._h5_root`)
-        ├── OPEP (HDF-group =(part, according to "partition_options")=> `Metaset` in a `Partition`)
-        │   ├── opep_0000 (HDF-group, => `MolData`)
-        │   │   ├── attrs (HDF-attributes of the molecule "/OPEP/opep_0000")
-        │   │   │   ├── cg_embeds (a 1-d numpy.int array)
-        │   │   │   ├── N_frames (int, number of frames = size of cg_coords on axis 0)
-        │   │   │   ... (optional, e.g., cg_top, cg_pdb, etc that corrsponds to the molecule)
-        │   │   ├── cg_coords (HDF-dataset of the molecule "/OPEP/opep_0000", 3-d numpy.float32 array)
-        │   │   └── cg(_delta)_forces (HDF-dataset of the molecule "/OPEP/opep_0000", 3-d numpy.float32 array)
-        │   ... (other molecules in "/OPEP")
-        ├── CATH (HDF-group ="partition_options"=> `Metaset` in a `Partition`)
-        ...
-
-
-> Data structure `MolData` is the basic brick of the dataset.
-It holds embeds, coords and forces of certain number of frames for a single molecule.
-.sub_sample: method for performing indexing on the frames.
-
-> Data strcuture `Metaset` holds multiple molecules and joins their frame indices together.
-One can access frames of underlying MolData objects with a continuous index.
-The idea is that the molecules in a `Metaset` have similar numbers of CG beads, such that the sample requires similar processing time when passing through a neural network.
-When this rule is enforced, it will allow automatic balancing of batch composition during training and validation.
-- .create_from_hdf5_group: initiate a Metaset by loading data from given HDF-group.
-mol_list, detailed_indices, hdf_key_mapping, stride and parallel can control which subset is loaded to the Metaset (details see the description of "H5Dataset")
-- .trim_down_to: drop frames of underlying for obtaining a subset with desired number of frames.
-The indices of frames to be dropped are controlled by a random number generator. When the parameter "random_seed" and the MolData order and number of frames are the same, the frames to be dropped will be reproducible.
-- len() (__len__): return total number of samples
-- [] (__get_item__): infer the molecule and get the corresponding frame according to the given unified index. Return value is grouped by an `AtomicData` object.
-
-
-> Data structure `Partition` can hold multiple Metaset for training and validation purposes.
-Its main function is to automatic adjust (subsample) the Metaset(s) and the underlying MolData to form a balanced data source, from which a certain number of batches can be drawn. Each batch will contain a pre-given number of samples from each Metaset.
-One or several `Partition`s can be created to load part of the same HDF5 file into the memory.
-The exact content inside a `Partition` object is controlled by the `partition_options` as a parameter for initializing a `H5Dataset`.
-
-> Data strcuture `H5Dataset` opens a HDF5 file and establish the partitions.
-`partition_options` describe what partitions to create and what content to load into them. (Detailed description and examples are as followed.)
-`loading_options` mainly deal with the HDF key mapping (which datasets/attributes corresponds to the coordinates, forces and embeddings) as well as (optionally) the information for correctly split the dataset in a parallel training/validation.
-
-An example "partition_options" (as a Python Mappable (e.g., dict)):
-
-.. code-block::
-
-        {
-                "train": {
-                        "metasets": {
-                                "OPEP": {
-                                        "molecules": [
-                                                "opep_0000",
-                                                "opep_0001",
-                                                ...
-                                        ],
-                                        "stride": 1, # optional, default 1
-                                        "detailed_indices": {
-                        # optional, providing the indices of frames to work with (before striding and splitting for parallel processes).
-                                                # optional,
-                            "opep_0000":
-                                val_ratio: 0.1
-                                test_ratio: 0.1
-                                seed: 12345
-                            "opep_0001":
-                                val_ratio: 0.1
-                                test_ratio: 0.1
-                                seed: 12345
-                            "filename": ./splits
-
-                        # If detailed_indices are not provided for a given molecule, then it is equivalent to np.arange(N_frames)
-                                                    "opep_0000": [1, 3, 5, 7, 9, ...],
-
-
-                                        },
-                                },
-                                "CATH": {
-                                        "molecules": [
-                                                "cath_1b43A02",
-                                                ...
-                                        ],
-                                        "stride": 1, # optional
-                                        "detailed_indices": {}, # optional
-                                }
-                        },
-                        "batch_size": {
-                                # each batch will contain 24 samples from
-                                # The two metasets will be trimmed down according to this ratio
-                                # so optimally it should be proportional to the ratio of numbers of frames in the metasets.
-                                "OPEP": 24,
-                                "CATH": 6,
-                        },
-                        "subsample_random_seed": 42, # optional, default 42. Random seed for trimming down the frames.
-                        "max_epoch_samples": None, # optional, default None. For setting a desired dataset size.
-                        # Works by subsampling the dataset after it is loaded with the given stride.
-                },
-                "val": { # similar
-                }
-        }
-
-An example "loading_options" (as a Python Mappable (e.g., dict)):
-
-.. code-block::
-
-        {
-                "hdf_key_mapping": {
-                        # keys for reading CG data from HDF5 groups
-                        "embeds": "attrs:cg_embeds",
-                        "coords": "cg_coords",
-                        "forces": "cg_delta_forces",
-                },
-                "parallel": { # optional, default rank=0 and world_size=1 (single process).
-                        # For split the dataset evenly and load only the necessary parts to each process in a parallelized train/val setup
-                        "rank": 0, # which process is this
-                        "world_size": 1, # how many processes are there
-                }
-        }
-
-
-> Class `H5PartitionDataLoader` mimics the pytorch data loader and can generate training/validation batches with fixed proportion of samples from several Metasets in a Partition.
-The proportion and batch size is defined when the partition is initialized.
-When the molecules in each Metaset have similar embedding vector lengths, the processing of output batches will require a more or less fixed size of VRAM on GPU, which can benefit the
-
-Note:
-1. Usually in a train-val split, each molecule goes to either the train or the test partition.
-     In some special cases (e.g., non-transferable training) one molecule can be part of both partitions.
-     In this situation, "detailed_indices" can be set to assign the corresponding frames to the desired partitions.
-     In addition one can pass in detailed_indices as a dictionary to split frames based on training/test (see partition_options example above)
-"""
-
 import h5py
 import numpy as np
 import torch
@@ -151,7 +12,7 @@ from mlcg.utils import make_splits, calc_num_samples, tqdm
 
 
 class MolData:
-    """Data-holder for coordinates, forces and embedding vector of a molecule, e.g., opep_0000.
+    r"""Data-holder for coordinates, forces and embedding vector of a molecule, e.g., opep_0000.
 
     Parameters
     ----------
@@ -239,7 +100,7 @@ class MolData:
 
 
 class MetaSet:
-    """Set of MolData instances for molecules with similar characterstics
+    r"""Set of MolData instances for molecules with similar characterstics
 
     Parameters
     ----------
@@ -273,7 +134,7 @@ class MetaSet:
         hdf5_group,
         mol_name,
     ):
-        """
+        r"""
         Returns number of frames for each mol name
         """
 
@@ -298,6 +159,10 @@ class MetaSet:
         subsample_using_weights=False,
         exclude_bonded_pairs=False,
     ):
+        r"""initiate a Metaset by loading data from given HDF-group.
+        mol_list, detailed_indices, hdf_key_mapping, stride and parallel can control which subset is loaded to the Metaset (details see the description of "H5Dataset")
+        """
+
         def select_for_rank(length_or_indices):
             """Return a slicing for loading the necessary data from the HDF dataset."""
             from numbers import Integral
@@ -408,7 +273,7 @@ class MetaSet:
         self._update_info()
 
     def trim_down_to(self, target_n_samples, random_seed=42, verbose=True):
-        """Trimming all datasets randomly to reach the target number of samples.
+        r"""Trimming all datasets randomly to reach the target number of samples.
         MolData attributes of the MetaSet are permanently subsampled by this
         method.
         """
@@ -530,7 +395,7 @@ class MetaSet:
 
 
 class Partition:
-    """Contain several metasets for a certain purpose, e.g., training.
+    r"""Contain several metasets for a certain purpose, e.g., training.
 
     Parameters
     ----------
@@ -644,7 +509,7 @@ class Partition:
 
 
 class H5Dataset:
-    """The top-level class for handling multiple datasets contained in a HDF5 file.
+    r"""The top-level class for handling multiple datasets contained in a HDF5 file.
 
     Parameters
     ----------
@@ -862,7 +727,7 @@ class H5Dataset:
 
 
 class H5SimpleDataset(H5Dataset):
-    """The top-level class for handling a single dataset contained in a HDF5 file.
+    r"""The top-level class for handling a single dataset contained in a HDF5 file.
     Will only load from one single type of molecules (i.e., one Metaset), and do
     not support partition splits.
     Use .get_dataloader for obtaining a dataloader for PyTorch training, etc.

--- a/mlcg/datasets/h5_dataset.py
+++ b/mlcg/datasets/h5_dataset.py
@@ -172,6 +172,7 @@ class MolData:
         coords: np.ndarray,
         forces: np.ndarray,
         weights: np.ndarray = None,
+        exclusion_pairs: np.ndarray = None,
     ):
         self._name = name
         self._embeds = embeds
@@ -186,6 +187,13 @@ class MolData:
         self._weights = weights
         if self._weights is not None:
             assert len(self._coords) == len(self._weights)
+
+        self._exclusion_pairs = exclusion_pairs
+        if self._exclusion_pairs is not None and self._exclusion_pairs.size > 0:
+            assert (
+                self._exclusion_pairs.min() >= 0
+                and self._exclusion_pairs.max() < len(self._embeds)
+            )
 
     @property
     def name(self):
@@ -206,6 +214,10 @@ class MolData:
     @property
     def weights(self):
         return self._weights
+
+    @property
+    def exclusion_pairs(self):
+        return self._exclusion_pairs
 
     @property
     def n_frames(self):
@@ -242,6 +254,7 @@ class MetaSet:
         self._mol_map = {}
         self._n_mol_samples = []
         self._cumulate_indices = [0]
+        self._exclude_bonded_pairs = False
 
     @staticmethod
     def retrieve_hdf(hdf_grp, hdf_key):
@@ -283,6 +296,7 @@ class MetaSet:
             "world_size": 1,
         },
         subsample_using_weights=False,
+        exclude_bonded_pairs=False,
     ):
         def select_for_rank(length_or_indices):
             """Return a slicing for loading the necessary data from the HDF dataset."""
@@ -322,6 +336,16 @@ class MetaSet:
                     % (mol_name, hdf5_group.name)
                 )
             embeds = MetaSet.retrieve_hdf(hdf5_group[mol_name], keys["embeds"])
+            if exclude_bonded_pairs:
+                if "exclusion_pairs" not in keys:
+                    raise ValueError(
+                        f"Missing `exclusion_pairs` from hdf5 key mapping."
+                    )
+                exclusion_pairs = MetaSet.retrieve_hdf(
+                    hdf5_group[mol_name], keys["exclusion_pairs"]
+                )
+            else:
+                exclusion_pairs = None
             if (
                 detailed_indices is not None
                 and detailed_indices.get(mol_name) is not None
@@ -372,8 +396,10 @@ class MetaSet:
                     coords,
                     forces,
                     weights=weights,
+                    exclusion_pairs=exclusion_pairs,
                 )
             )
+        output._exclude_bonded_pairs = exclude_bonded_pairs
         return output
 
     def insert_mol(self, mol_data):
@@ -470,11 +496,16 @@ class MetaSet:
 
     def __getitem__(self, idx):
         dataset_id, data_id = self._locate_idx(idx)
-        return AtomicData.from_points(
+        atd = AtomicData.from_points(
             pos=self._mol_dataset[dataset_id].coords[data_id],
             forces=self._mol_dataset[dataset_id].forces[data_id],
             atom_types=self._mol_dataset[dataset_id].embeds,
         )
+        if self._exclude_bonded_pairs:
+            atd.exc_pair_index = torch.tensor(
+                self._mol_dataset[dataset_id].exclusion_pairs
+            )
+        return atd
 
     def _locate_idx(self, idx):
         full_length = self._cumulate_indices[-1]
@@ -632,6 +663,7 @@ class H5Dataset:
         partition_options: Dict,
         loading_options: Dict,
         subsample_using_weights: bool = False,
+        exclude_bonded_pairs: bool = False,
     ):
         self._h5_path = h5_file_path
         self._h5_root = h5py.File(h5_file_path, "r")
@@ -641,6 +673,7 @@ class H5Dataset:
         self._partition_sample_info = {}
         self._detailed_indices = {}
         self._subsample_using_weights = subsample_using_weights
+        self._exclude_bonded_pairs = exclude_bonded_pairs
 
         # processing the hdf5 file
         for metaset_name in self._h5_root:
@@ -711,6 +744,7 @@ class H5Dataset:
                         hdf_key_mapping=hdf_key_mapping,
                         parallel=parallel,
                         subsample_using_weights=self._subsample_using_weights,
+                        exclude_bonded_pairs=self._exclude_bonded_pairs,
                     ),
                 )
             ## trim the metasets to fit the need of sampling
@@ -868,6 +902,7 @@ class H5SimpleDataset(H5Dataset):
         },
         parallel={"rank": 0, "world_size": 1},
         subsample_using_weights: Optional[bool] = False,
+        exclude_bonded_pairs: bool = False,
     ):
         # input checking
         if not isinstance(stride, int) and stride > 0:
@@ -913,6 +948,7 @@ class H5SimpleDataset(H5Dataset):
             hdf_key_mapping=hdf_key_mapping,
             parallel=parallel,
             subsample_using_weights=subsample_using_weights,
+            exclude_bonded_pairs=exclude_bonded_pairs,
         )
 
     def get_dataloader(

--- a/mlcg/datasets/h5_dataset.py
+++ b/mlcg/datasets/h5_dataset.py
@@ -115,7 +115,7 @@ class MetaSet:
         self._mol_map = {}
         self._n_mol_samples = []
         self._cumulate_indices = [0]
-        self._exclude_bonded_pairs = False
+        self._exclude_listed_pairs = False
 
     @staticmethod
     def retrieve_hdf(hdf_grp, hdf_key):
@@ -157,7 +157,7 @@ class MetaSet:
             "world_size": 1,
         },
         subsample_using_weights=False,
-        exclude_bonded_pairs=False,
+        exclude_listed_pairs=False,
     ):
         r"""initiate a Metaset by loading data from given HDF-group.
         mol_list, detailed_indices, hdf_key_mapping, stride and parallel can control which subset is loaded to the Metaset (details see the description of "H5Dataset")
@@ -201,7 +201,7 @@ class MetaSet:
                     % (mol_name, hdf5_group.name)
                 )
             embeds = MetaSet.retrieve_hdf(hdf5_group[mol_name], keys["embeds"])
-            if exclude_bonded_pairs:
+            if exclude_listed_pairs:
                 if "exclusion_pairs" not in keys:
                     raise ValueError(
                         f"Missing `exclusion_pairs` from hdf5 key mapping."
@@ -264,7 +264,7 @@ class MetaSet:
                     exclusion_pairs=exclusion_pairs,
                 )
             )
-        output._exclude_bonded_pairs = exclude_bonded_pairs
+        output._exclude_listed_pairs = exclude_listed_pairs
         return output
 
     def insert_mol(self, mol_data):
@@ -366,7 +366,7 @@ class MetaSet:
             forces=self._mol_dataset[dataset_id].forces[data_id],
             atom_types=self._mol_dataset[dataset_id].embeds,
         )
-        if self._exclude_bonded_pairs:
+        if self._exclude_listed_pairs:
             atd.exc_pair_index = torch.tensor(
                 self._mol_dataset[dataset_id].exclusion_pairs
             )
@@ -528,7 +528,7 @@ class H5Dataset:
         partition_options: Dict,
         loading_options: Dict,
         subsample_using_weights: bool = False,
-        exclude_bonded_pairs: bool = False,
+        exclude_listed_pairs: bool = False,
     ):
         self._h5_path = h5_file_path
         self._h5_root = h5py.File(h5_file_path, "r")
@@ -538,7 +538,7 @@ class H5Dataset:
         self._partition_sample_info = {}
         self._detailed_indices = {}
         self._subsample_using_weights = subsample_using_weights
-        self._exclude_bonded_pairs = exclude_bonded_pairs
+        self._exclude_listed_pairs = exclude_listed_pairs
 
         # processing the hdf5 file
         for metaset_name in self._h5_root:
@@ -609,7 +609,7 @@ class H5Dataset:
                         hdf_key_mapping=hdf_key_mapping,
                         parallel=parallel,
                         subsample_using_weights=self._subsample_using_weights,
-                        exclude_bonded_pairs=self._exclude_bonded_pairs,
+                        exclude_listed_pairs=self._exclude_listed_pairs,
                     ),
                 )
             ## trim the metasets to fit the need of sampling
@@ -767,7 +767,7 @@ class H5SimpleDataset(H5Dataset):
         },
         parallel={"rank": 0, "world_size": 1},
         subsample_using_weights: Optional[bool] = False,
-        exclude_bonded_pairs: bool = False,
+        exclude_listed_pairs: bool = False,
     ):
         # input checking
         if not isinstance(stride, int) and stride > 0:
@@ -813,7 +813,7 @@ class H5SimpleDataset(H5Dataset):
             hdf_key_mapping=hdf_key_mapping,
             parallel=parallel,
             subsample_using_weights=subsample_using_weights,
-            exclude_bonded_pairs=exclude_bonded_pairs,
+            exclude_listed_pairs=exclude_listed_pairs,
         )
 
     def get_dataloader(

--- a/mlcg/datasets/utils.py
+++ b/mlcg/datasets/utils.py
@@ -373,3 +373,27 @@ def write_PSF(
                 string = ["{:>8d}".format(x) for x in print_list]
                 string = "".join(string)
                 file.write(string + "\n")
+
+
+def get_exclusion_pairs_from_neighborlist(
+    nl_dict, ignore_terms=("non_bonded", "gamma_1", "gamma_2")
+):
+    """Extract the exclusion pairs for a molecule given the neighbor list used.
+    For term of order bigger than 2, extracting the pairs formed by the first and last bead.
+
+    Input
+    -----
+    nl_dict: dict of neighbor list dictionaries, each of which contains an `index_mapping`
+    ignore_terms: sequence of str, names of terms to be ignored, e.g., "non_bonded"
+
+    Output
+    ------
+    int Tensor of shape (2, N_pairs) with all pairs extracted from the the neighbor list.
+    """
+    exc_pairs = []
+    for term_name, term in nl_dict.items():
+        if term_name not in ignore_terms:
+            exc_pairs.append(term["index_mapping"][[0, -1]].T)
+            exc_pairs.append(term["index_mapping"][[-1, 0]].T)
+    exc_pairs = torch.unique(torch.cat(exc_pairs), dim=1).T
+    return exc_pairs

--- a/mlcg/nn/schnet.py
+++ b/mlcg/nn/schnet.py
@@ -135,6 +135,11 @@ class SchNet(torch.nn.Module):
             if (radius_distance is not None) and x.is_cuda:
                 use_custom_kernel = True
             if not use_custom_kernel:
+                if hasattr(data, "exc_pair_index"):
+                    raise NotImplementedError(
+                        "Excluding pairs requires `mlcg_opt_radius` "
+                        "to be available and model running with CUDA."
+                    )
                 neighbor_list = self.neighbor_list(
                     data,
                     self.rbf_layer.cutoff.cutoff_upper,
@@ -147,6 +152,7 @@ class SchNet(torch.nn.Module):
                 data.batch,
                 False,  # no loop edges due to compatibility & backward breaks with zero distance
                 self.max_num_neighbors,
+                exclude_pair_indices=data.get("exc_pair_index"),
             )
         else:
             edge_index = neighbor_list["index_mapping"]

--- a/mlcg/pl/h5_data.py
+++ b/mlcg/pl/h5_data.py
@@ -49,13 +49,13 @@ class H5DataModule(pl.LightningDataModule):
             "hdf_key_mapping": default_key_mapping
         },
         subsample_using_weights: bool = False,
-        exclude_bonded_pairs: bool = False,
+        exclude_listed_pairs: bool = False,
     ):
         super(H5DataModule, self).__init__()
         self.save_hyperparameters()
         self._h5_file_path = h5_file_path
         self._subsample_using_weights = subsample_using_weights
-        self._exclude_bonded_pairs = exclude_bonded_pairs
+        self._exclude_listed_pairs = exclude_listed_pairs
 
         def get_options(options_or_path):
             if isinstance(options_or_path, Mapping):
@@ -104,7 +104,7 @@ class H5DataModule(pl.LightningDataModule):
             self._part_options,
             self._process_load_options,
             self._subsample_using_weights,
-            self._exclude_bonded_pairs,
+            self._exclude_listed_pairs,
         )
         if use_ddp:
             sample_info = [None] * num_replicas

--- a/mlcg/pl/h5_data.py
+++ b/mlcg/pl/h5_data.py
@@ -49,11 +49,13 @@ class H5DataModule(pl.LightningDataModule):
             "hdf_key_mapping": default_key_mapping
         },
         subsample_using_weights: bool = False,
+        exclude_bonded_pairs: bool = False,
     ):
         super(H5DataModule, self).__init__()
         self.save_hyperparameters()
         self._h5_file_path = h5_file_path
         self._subsample_using_weights = subsample_using_weights
+        self._exclude_bonded_pairs = exclude_bonded_pairs
 
         def get_options(options_or_path):
             if isinstance(options_or_path, Mapping):
@@ -102,6 +104,7 @@ class H5DataModule(pl.LightningDataModule):
             self._part_options,
             self._process_load_options,
             self._subsample_using_weights,
+            self._exclude_bonded_pairs,
         )
         if use_ddp:
             sample_info = [None] * num_replicas

--- a/opt_radius/MANIFEST.in
+++ b/opt_radius/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+recursive-include mlcg_opt_radius *.h *.hxx *.hpp *.c *.cpp *.cxx *.cu
+

--- a/opt_radius/README.md
+++ b/opt_radius/README.md
@@ -1,0 +1,40 @@
+# mlcg_opt_radius
+
+This submodule provides a custom CUDA kernel for neighbor list construction 
+that can be used by SchNet. In most cases this kernel has a faster performance
+than the naive python implementation.
+
+This kernel also provides additional features such as the possibility of excluding
+certain edges from the graph defined by the neighbohr list.
+
+## Pre-installation: NVCC match
+
+Contrary to `mlcg`, which can be ran just using the CUDA runtime, this module
+compiles the custom kernel and as such it requires to have an existing installation 
+of nvcc, the CUDA compiler.
+
+Pytorch will only be able to use this kernel if the installed Pytorch version is 
+compatible with the major version of NVCC (for example, PyTorch for cuda 12.1 will 
+work )
+
+**Make sure that your PyTorch installation is compatible with NVCC**. You can find 
+the instruction to install PyTorch for a variety of CUDA versions at their [official documentation](https://pytorch.org/get-started/locally/)
+
+
+## Installation 
+
+From this directory, run `python setup.py develop`. 
+
+Some information from the NVCC will print on the screen. After some minutes, installation should be complete.
+
+## Usage
+
+If installed, the custom kernel will be used by default without further tweaking.
+
+### Pair exclusion
+
+To enable the exclusion of certain edges from the neighbohrlist, you need to pass
+the exclusion list as an attribute of the molecule in an H5 dataset. See the 
+description of the structure in  documentation of `H5Dataset` for further idea.
+
+An example of the training input yaml enabling the eexlusions  can be found in `examples/h5_pl/train_h5_1_10_exclusion.yaml`

--- a/opt_radius/mlcg_opt_radius/__init__.py
+++ b/opt_radius/mlcg_opt_radius/__init__.py
@@ -1,8 +1,9 @@
 from . import radius
 
-try:
-    from . import radius_cu
-except ImportError:
-    print(
-        "Package `mlcg_opt_radius` was not installed. Running with JIT compilation."
-    )
+# import torch
+# try:
+#     from . import radius_opt
+# except ImportError:
+#     print(
+#         "Package `mlcg_opt_radius` was not installed. Running with JIT compilation."
+#     )

--- a/opt_radius/mlcg_opt_radius/binding.cpp
+++ b/opt_radius/mlcg_opt_radius/binding.cpp
@@ -1,0 +1,23 @@
+#include <torch/extension.h>
+#include <tuple>
+
+namespace mlcg_opt_radius {
+    
+    std::tuple<torch::Tensor, torch::Tensor> 
+    radius_cuda(const torch::Tensor x, 
+                torch::optional<torch::Tensor> ptr_x,
+                const double r,
+                const int64_t max_num_neighbors,
+                const bool ignore_same_index,
+                torch::optional<torch::Tensor> exclude_pair_xs,
+                torch::optional<torch::Tensor> ptr_exclude_pair_xs);
+
+    std::tuple<torch::Tensor, torch::Tensor> 
+    exclusion_pair_to_ptr(const torch::Tensor exc_pair_index, 
+                        const int64_t num_nodes);
+
+    PYBIND11_MODULE(TORCH_EXTENSION_NAME, m){
+        m.def("exclusion_pair_to_ptr", &exclusion_pair_to_ptr);
+        m.def("radius_cuda", &radius_cuda);
+    }
+}

--- a/opt_radius/mlcg_opt_radius/exclusion_pairs.cpp
+++ b/opt_radius/mlcg_opt_radius/exclusion_pairs.cpp
@@ -1,0 +1,66 @@
+#include <torch/extension.h>
+#include <tuple>
+
+// using namespace torch::indexing;
+namespace mlcg_opt_radius {
+
+std::tuple<torch::Tensor, torch::Tensor> 
+exclusion_pair_to_ptr(const torch::Tensor exc_pair_index, 
+                      const int64_t num_nodes) {
+    // prepare and convert exclusion pairs for CUDA kernels
+    // `exc_pair_index` contains pairs (x, y) 
+    // `num_nodes` is the number of nodes in the graph
+    // (it needs to be provided explicitly to avoid errors)
+    // we perform a lex_sort by primary key y and secondary key x
+    // then we take all the xs out, and mark the starting and stopping index for each y
+    // e.g., exc_pair_index = [(2, 1), (1, 2), (3, 2), (2, 2), (2, 3)], num_nodes = 4 ->
+    // pair_xs = [2, 1, 3, 2, 2] (length = number of pairs)
+    // y_ptr = [0, 1, 4, 5, 5] (length = num_nodes + 1)
+
+    // ensure dtype & device
+    TORCH_CHECK(exc_pair_index.dtype() == at::kLong);
+    bool IsFromCPU = exc_pair_index.device().type() == at::DeviceType::CPU;
+    const at::Tensor cpu_exc_pair_index = IsFromCPU ? exc_pair_index : exc_pair_index.to(at::kCPU);
+
+    // TORCH_INTERNAL_ASSERT(exc_pair_index.device().type() == at::DeviceType::CPU);
+    TORCH_CHECK(cpu_exc_pair_index.dim() == 2);
+    TORCH_CHECK(cpu_exc_pair_index.size(0) == 2);
+    at::Tensor a_contig = cpu_exc_pair_index.contiguous();
+    // a lexsort over the pair indices
+    const at::Tensor col_0 = a_contig.index({0});
+    const at::Tensor col_1 = a_contig.index({1});
+    at::Tensor indicex = at::argsort(col_0, true);
+    const at::Tensor col_1_new = col_1.index({indicex});
+    indicex = indicex.index({at::argsort(col_1_new, true)});
+    at::Tensor pair_xs = col_0.index({indicex});
+    const at::Tensor pair_ys = col_1.index({indicex});
+    // convert to pair_xs and y_ptr
+    auto n_pairs = pair_xs.size(0);
+    auto y_ptr = torch::empty(num_nodes + 1, cpu_exc_pair_index.options());
+    const int64_t* pair_ys_arr = pair_ys.data_ptr<int64_t>();
+    int64_t* y_ptr_arr = y_ptr.data_ptr<int64_t>();
+    y_ptr_arr[0] = 0;
+    int64_t i_pair = 0;
+    int64_t current_pair_y;
+    for (int64_t n_y = 0; n_y < num_nodes; n_y++) {
+        while (i_pair < n_pairs) {
+            current_pair_y = pair_ys_arr[i_pair];
+            TORCH_CHECK(current_pair_y >= n_y);
+            if (current_pair_y == n_y)
+                i_pair++;
+            else break;
+        }
+        y_ptr_arr[n_y + 1] = i_pair;
+    }
+    // move to device if not CPU
+    if (!IsFromCPU) {
+        pair_xs = pair_xs.to(exc_pair_index);
+        y_ptr = y_ptr.to(exc_pair_index);
+    }
+        
+    return std::make_tuple(pair_xs, y_ptr);
+}
+
+static auto registry =
+    torch::RegisterOperators().op("mlcg::exclusion_pair_to_ptr", &exclusion_pair_to_ptr);
+}

--- a/opt_radius/mlcg_opt_radius/radius.cu
+++ b/opt_radius/mlcg_opt_radius/radius.cu
@@ -10,6 +10,7 @@
 
 namespace cg = cooperative_groups;
 
+namespace mlcg_opt_radius {
 //-------------------------------------------------------------------
 __forceinline__ 
 __device__ 
@@ -22,6 +23,38 @@ get_example_idx(int64_t idx,
             return i;
     }
     return num_examples - 1;
+}
+//-------------------------------------------------------------------
+__forceinline__
+__device__
+int64_t
+is_in_sorted_array(const int64_t query,
+		           const int64_t *arr_to_be_searched,
+		           int64_t& current_search_id,
+                   const int64_t max_search_id) {
+    // a routine to search along a sorted array
+    // current_search_id++ and compare the value with query
+    // |- smaller -> continue
+    // |- equal -> stop, return true
+    // |- larger -> stop, return false
+    // till the max_search_id
+    // Warning: current_search_id is taken by reference and will change
+    // To have it functioning properly, the input query need to be monotonically 
+    // increasing over consequtive calls
+    int64_t current_v;
+    while (current_search_id < max_search_id) {
+        current_v = arr_to_be_searched[current_search_id];
+        if (current_v < query) {
+                current_search_id++;
+        }
+        else if (current_v == query) {
+                return true;
+        }
+	    else return false; // pointing at a value bigger than the query
+    }
+    if (current_search_id == max_search_id) {
+        return false; // we have drained the search
+    }
 }
 //-------------------------------------------------------------------
 template <typename scalar_t>
@@ -56,6 +89,8 @@ template <typename scalar_t>
 __global__ void
 radius_kernel(const scalar_t *__restrict__ x, 
               const int64_t *__restrict__ ptr_x,
+              const int64_t *__restrict__ exclude_pair_xs,
+	          const int64_t *__restrict__ ptr_exclude_pair_xs,
               const scalar_t r, 
               const int64_t n,
               const int64_t dim, 
@@ -75,13 +110,28 @@ radius_kernel(const scalar_t *__restrict__ x,
     int64_t count = 0;
     const int64_t example_idx = get_example_idx(n_y, ptr_x, num_examples);
 
+    // these inputs should be prepared in a manner:
+    // considering pairs (x, y) sorted by primary key y and secondary key x
+    // we can take all the xs out, and mark the starting and stopping index for each y
+    // e.g., [(2, 1), (1, 2), (3, 2), (2, 2), (2, 3)] ->
+    // exclude_pair_xs = [2, 1, 3, 2, 2] (length = number of pairs)
+    // and ptr_exclude_pair_xs = [0, 1, 4, 5] (length = y_max + 1)
+    // this is similar to x and ptr_x, the difference is that the latter is with respect
+    // to each frame, and the ptr_exclude_pair_xs are indices for each node_index y
+    // see also `exclusion_pair_to_ptr` in exlcusion_pairs.cpp
+    int64_t exc_pair_i = ptr_exclude_pair_xs[n_y];
+    int64_t bound_exc_pair_i = ptr_exclude_pair_xs[n_y + 1];
+
     for (int64_t n_x = ptr_x[example_idx]; n_x < ptr_x[example_idx + 1]; n_x++) {
         scalar_t dist = 0;
         for (int64_t d = 0; d < dim; d++) {
             dist += (x[n_x * dim + d] - x[n_y * dim + d]) *
                     (x[n_x * dim + d] - x[n_y * dim + d]);
         }
-        if ((dist < r) && !(ignore_same_index && (n_y == n_x))) {
+	    bool is_excluded = is_in_sorted_array(
+            n_x, exclude_pair_xs, exc_pair_i, bound_exc_pair_i
+        );
+        if (!is_excluded && (dist < r) && !(ignore_same_index && (n_y == n_x))) {
             o_edge_index[(n_y * max_num_neighbors * 2) + (count * 2)    ] = n_y;
             o_edge_index[(n_y * max_num_neighbors * 2) + (count * 2) + 1] = n_x;
             o_distance[(n_y * max_num_neighbors) + count] = sqrt(dist); //squared
@@ -149,7 +199,9 @@ std::tuple<torch::Tensor, torch::Tensor>
                           torch::optional<torch::Tensor> ptr_x,
                           const double r,
                           const int64_t max_num_neighbors,
-                          const bool ignore_same_index) {
+                          const bool ignore_same_index,
+                          torch::optional<torch::Tensor> exclude_pair_xs,
+                          torch::optional<torch::Tensor> ptr_exclude_pair_xs) {
     CHECK_CUDA(x);
     CHECK_CONTIGUOUS(x);
     CHECK_INPUT(x.dim() == 2);
@@ -161,6 +213,20 @@ std::tuple<torch::Tensor, torch::Tensor>
     } else
         ptr_x = torch::arange(0, x.size(0) + 1, x.size(0),
                               x.options().dtype(torch::kLong));
+    
+    if (exclude_pair_xs.has_value()) {
+        CHECK_CUDA(exclude_pair_xs.value());
+        CHECK_INPUT(exclude_pair_xs.value().dim() == 1);
+        CHECK_INPUT(ptr_exclude_pair_xs.has_value());
+        CHECK_CUDA(ptr_exclude_pair_xs.value());
+        CHECK_INPUT(ptr_exclude_pair_xs.value().dim() == 1);
+        CHECK_INPUT(ptr_exclude_pair_xs.value().size(0) == x.size(0) + 1);
+    } else {
+        // no pairs to be exlcuded? Generate an empty input
+        exclude_pair_xs = torch::empty(1, x.options().dtype(torch::kLong));
+        ptr_exclude_pair_xs = torch::zeros(x.size(0) + 1, x.options().dtype(torch::kLong));
+    }
+        
 
     auto scalar_type = x.scalar_type();
     dim3 BLOCKS((x.size(0) + THREADS - 1) / THREADS);
@@ -179,6 +245,8 @@ std::tuple<torch::Tensor, torch::Tensor>
 
             scalar_t* x_data_ptr = x.data_ptr<scalar_t>();
             int64_t* ptr_x_ptr = ptr_x.value().data_ptr<int64_t>();
+            int64_t* exclude_pair_xs_ptr = exclude_pair_xs.value().data_ptr<int64_t>();
+            int64_t* ptr_exclude_pair_xs_ptr = ptr_exclude_pair_xs.value().data_ptr<int64_t>();
             scalar_t r_squared = r*r;
             int64_t x_size0 = x.size(0);
             int64_t x_size1 = x.size(1);
@@ -189,6 +257,8 @@ std::tuple<torch::Tensor, torch::Tensor>
             void* kernel_args[] = {
                 (void*)&x_data_ptr,
                 (void*)&ptr_x_ptr,
+                (void*)&exclude_pair_xs_ptr,
+                (void*)&ptr_exclude_pair_xs_ptr,
                 (void*)&r_squared,  
                 (void*)&x_size0,    
                 (void*)&x_size1,    
@@ -236,6 +306,11 @@ std::tuple<torch::Tensor, torch::Tensor>
     return std::make_tuple(o_c_edge_index.t(), o_c_distance);
 }
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m){
-    m.def("radius_cuda", &radius_cuda);
+// PYBIND11_MODULE(TORCH_EXTENSION_NAME, m){
+//     m.def("radius_cuda", &radius_cuda);
+// }
+
+static auto registry =
+    torch::RegisterOperators().op("mlcg::radius_cuda", &radius_cuda);
+
 }

--- a/opt_radius/mlcg_opt_radius/radius.py
+++ b/opt_radius/mlcg_opt_radius/radius.py
@@ -17,7 +17,7 @@ try:
         extra_cflags=["-O3"],
         extra_cuda_cflags=["-O3"],
     )
-except Error as e:
+except Exception as e:
     # we save the error message instead of raising it immediately
     # but rather raise it when `radius_cuda` is actually called
     class DelayedError:

--- a/opt_radius/mlcg_opt_radius/test_radius.py
+++ b/opt_radius/mlcg_opt_radius/test_radius.py
@@ -9,9 +9,13 @@ from torch.autograd import gradcheck, gradgradcheck
 
 from torch_cluster import radius_graph as rgo
 
+skip_test = False
 try:
     from .radius import radius_distance as rgm
 except RuntimeError:
+    skip_test = True
+
+if skip_test or not torch.cuda.is_available():
     pytest.skip(
         "Cuda device is required for this test. Skipping ...",
         allow_module_level=True,

--- a/opt_radius/mlcg_opt_radius/test_radius.py
+++ b/opt_radius/mlcg_opt_radius/test_radius.py
@@ -66,7 +66,6 @@ TOL = 1e-6
 def test_radius(
     x_c, dim, x_range, r, batch_size, max_num_neighbors, loop, fdtype, device
 ):
-    return
     (x_min, x_max) = x_range
     x = (x_max - x_min) * torch.rand(
         (x_c, dim), dtype=fdtype, device=device

--- a/opt_radius/setup.py
+++ b/opt_radius/setup.py
@@ -1,17 +1,27 @@
 from setuptools import find_packages, setup, Extension
 from torch.utils import cpp_extension
 
+
+VERSION = "0.0.1"
+
 setup(
     name="mlcg_opt_radius",
     packages=find_packages(),
     ext_modules=[
         cpp_extension.CUDAExtension(
-            "mlcg_opt_radius.radius_cu",
-            ["mlcg_opt_radius/radius.cu"],
+            "mlcg_opt_radius.radius_opt",
+            [
+                f"mlcg_opt_radius/{src}"
+                for src in ["binding.cpp", "radius.cu", "exclusion_pairs.cpp"]
+            ],
             py_limited_api=True,
             extra_compile_args={"cxx": ["-O3"], "nvcc": ["-O3"]},
         ),
     ],
+    python_requires=">=3.9",
+    license="MIT",
+    author="Paul Mifsud, Yaoyi Chen",
+    install_requires=["torch"],
     cmdclass={
         "build_ext": cpp_extension.BuildExtension.with_options(
             no_python_abi_suffix=True, use_ninja=False

--- a/opt_radius/setup.py
+++ b/opt_radius/setup.py
@@ -7,6 +7,7 @@ VERSION = "0.0.1"
 setup(
     name="mlcg_opt_radius",
     packages=find_packages(),
+    include_package_data=True,
     ext_modules=[
         cpp_extension.CUDAExtension(
             "mlcg_opt_radius.radius_opt",
@@ -16,6 +17,7 @@ setup(
             ],
             py_limited_api=True,
             extra_compile_args={"cxx": ["-O3"], "nvcc": ["-O3"]},
+            optional=True,
         ),
     ],
     python_requires=">=3.9",


### PR DESCRIPTION
# PR Checklist

- [] Bug fix
- [x] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

### Describe your changes here:
This enables excluding a list of pairs from the schnet convolution. Most of the changes in this PR are dedicated to achieve this without slowing down.
In order to use this, one has to install the custom kernel "mlcg_radius_opt" which is in a separate folder in the root of this repository, see `opt_radius/setup.py`.
The list of exclusion pairs can be automatically generated from corresponding neighbor list, see method `mlcg.datasets.utils.get_exclusion_pairs_from_neighborlist` and its doc string for details.
After that, the exclusion list needs to be stored in the h5 datsets, either as a "dataset" or "attribute" under the h5 group for the corresponding molecule.
In order to exclude this list of pairs, one needs to add the following lines with "<<<" to the config file for training.
```yaml
data:
  loading_options:
    hdf_key_mapping:
      embeds: attrs:cg_embeds
      coords: cg_coords
      forces: cg_delta_forces
      exclusion_pairs: attrs:cg_exc_pairs # <<< depending on the key name for the pair list
  exclude_bonded_pairs: true # <<<
```
In order to simulate a molecule with such a model, one need to attach the exclusion pairs as a tensor with name "exc_pair_index" to the starting conformations. For each `AtomicData` object `config` in that list,
```python
config.exc_pair_index = exclusion_pairs
```
And then the simulation can be run without further modifications.
