### PR TITLE
Simulation data saving

### DIFF
--- a/mlcg/simulation/base.py
+++ b/mlcg/simulation/base.py
@@ -315,7 +315,7 @@ class _Simulation(object):
                 # it only happens when time points are also recorded
                 if self.export_interval is not None:
                     if (t + 1) % self.export_interval == 0:
-                        self.write((t + 1) // self.save_interval)
+                        self.write()
                         if self.save_subroutine is not None:
                             self.save_subroutine(
                                 data, (t + 1) // self.save_interval
@@ -338,7 +338,7 @@ class _Simulation(object):
         # if relevant, save the remainder of the simulation
         if self.export_interval is not None:
             if int(t + 1) % self.export_interval > 0:
-                self.write(t + 1)
+                self.write()
 
         # if relevant, log that simulation has been completed
         if self.log_interval is not None:
@@ -348,7 +348,7 @@ class _Simulation(object):
 
         self._simulated = True
 
-        return self.simulated_coords
+        return
 
     def log(self, iter_: int):
         """Utility to print log statement or write it to an text file"""
@@ -581,16 +581,8 @@ class _Simulation(object):
                     # the `current_timestep` in the checkpoint is actually the number of the last
                     # numpy filed saved. We need to use it to reset the _npy_file_index
                     self._npy_file_index = self.current_timestep
-                    # We also need to reset _npy_starting_index, which should carry the last simulation timestep
-                    # in which we saved coordinates, divided by the save interval
-                    self._npy_starting_index = (
-                        self.current_timestep
-                        * self.export_interval
-                        // self.save_interval
-                    )
                 else:
                     self._npy_file_index = 0
-                    self._npy_starting_index = 0
 
         # logging
         if self.log_interval is not None:
@@ -660,7 +652,7 @@ class _Simulation(object):
                 "To rerun, set overwrite=True."
             )
 
-        self._save_size = int(self.n_timesteps / self.save_interval)
+        self._save_size = int(self.export_interval / self.save_interval)
 
         self.simulated_coords = torch.zeros(
             (self._save_size, self.n_sims, self.n_atoms, self.n_dims)
@@ -723,11 +715,8 @@ class _Simulation(object):
                 f"Simulation of trajectory blew up at #timestep={t}"
             )
 
-            # tt = pos_spread > 1e3*self.initial_pos_spread
-            # traj_ids = torch.where(tt == True)[0]
-            # raise RuntimeError(f'Simulation of trajectory {traj_ids} blew up at #timestep={t} with pos= \n {x_new[tt]}')
 
-        save_ind = t // self.save_interval
+        save_ind = (t // self.save_interval) - self._npy_file_index * self._save_size
 
         self.simulated_coords[save_ind, :, :] = x_new
 
@@ -742,7 +731,7 @@ class _Simulation(object):
                 ]
                 self.simulated_potential = torch.zeros((potential_dims))
 
-            self.simulated_potential[t // self.save_interval] = potential
+            self.simulated_potential[save_ind] = potential
 
         if self.create_checkpoints:
             self.checkpoint = {}
@@ -753,29 +742,23 @@ class _Simulation(object):
                 data[VELOCITY_KEY].detach()
             )
 
-    def write(self, iter_: int):
+    def write(self):
         """Utility to write numpy arrays to disk"""
         key = self._get_numpy_count()
 
-        coords_to_export = self.simulated_coords[
-            self._npy_starting_index : iter_
-        ]
+        coords_to_export = self.simulated_coords
         coords_to_export = self._swap_and_export(coords_to_export)
         np.save("{}_coords_{}.npy".format(self.filename, key), coords_to_export)
 
         if self.save_forces:
-            forces_to_export = self.simulated_forces[
-                self._npy_starting_index : iter_
-            ]
+            forces_to_export = self.simulated_forces
             forces_to_export = self._swap_and_export(forces_to_export)
             np.save(
                 "{}_forces_{}.npy".format(self.filename, key), forces_to_export
             )
 
         if self.save_energies:
-            potentials_to_export = self.simulated_potential[
-                self._npy_starting_index : iter_
-            ]
+            potentials_to_export = self.simulated_potential
             potentials_to_export = self._swap_and_export(potentials_to_export)
             np.save(
                 "{}_potential_{}.npy".format(self.filename, key),
@@ -783,7 +766,7 @@ class _Simulation(object):
             )
 
         if self.create_checkpoints:
-            self.checkpoint["current_timestep"] = int(key) + 1
+            self.checkpoint["current_timestep"] = self._npy_file_index + 1
             self.checkpoint["export_interval"] = self.export_interval
             self.checkpoint["save_interval"] = self.save_interval
             self.checkpoint["log_interval"] = self.log_interval
@@ -792,7 +775,22 @@ class _Simulation(object):
                 "{}_checkpoint.pt".format(self.filename),
             )
 
-        self._npy_starting_index = iter_
+        # Reset simulated coords, forces and potential
+        self.simulated_coords = torch.zeros(
+            (self._save_size, self.n_sims, self.n_atoms, self.n_dims)
+        )
+        if self.save_forces:
+            self.simulated_forces = torch.zeros(
+                (self._save_size, self.n_sims, self.n_atoms, self.n_dims)
+            )
+        else:
+            self.simulated_forces = None
+
+        if self.save_energies:
+            self.simulated_potential = torch.zeros(self._save_size, self.n_sims)
+        else:
+            self.simulated_potential = None
+
         self._npy_file_index += 1
 
     def reshape_output(self):

--- a/mlcg/simulation/base.py
+++ b/mlcg/simulation/base.py
@@ -64,7 +64,7 @@ class _Simulation(object):
     dtype : str, default='single'
         precision to run the simulation with (single or double)
     export_interval : int, default=None
-        If not None, .npy files will be saved. If an int is given, then
+        Interval at which .npy files will be saved. If an int is given, then
         the int specifies at what intervals numpy files will be saved per
         observable. This number must be an integer multiple of save_interval.
         All output files should be the same shape. Forces and potentials will
@@ -72,6 +72,8 @@ class _Simulation(object):
         arguments, respectively. If friction is not None, kinetic energies
         will also be saved. This method is only implemented for a maximum of
         1000 files per observable due to file naming conventions.
+        If None, export_interval will be set to n_timesteps to output one file
+        for the entire simulation
     log_interval : int, default=None
         If not None, a log will be generated indicating simulation start and
         end times as well as completion updates at regular intervals. If an
@@ -140,7 +142,10 @@ class _Simulation(object):
             self.dtype = torch.float64
 
         self.device = torch.device(device)
-        self.export_interval = export_interval
+        if export_interval is None:
+            self.export_interval = self.n_timesteps
+        else:
+            self.export_interval = export_interval
         self.log_interval = log_interval
         self.create_checkpoints = create_checkpoints
         self.read_checkpoint_file = read_checkpoint_file

--- a/mlcg/simulation/base.py
+++ b/mlcg/simulation/base.py
@@ -715,8 +715,9 @@ class _Simulation(object):
                 f"Simulation of trajectory blew up at #timestep={t}"
             )
 
-
-        save_ind = (t // self.save_interval) - self._npy_file_index * self._save_size
+        save_ind = (
+            t // self.save_interval
+        ) - self._npy_file_index * self._save_size
 
         self.simulated_coords[save_ind, :, :] = x_new
 

--- a/mlcg/simulation/langevin.py
+++ b/mlcg/simulation/langevin.py
@@ -158,13 +158,11 @@ class LangevinSimulation(_Simulation):
         # Initialize velocities according to Maxwell-Boltzmann distribution
         if VELOCITY_KEY not in self.initial_data:
             # initialize velocities at zero
-            self.initial_data[
-                VELOCITY_KEY
-            ] = LangevinSimulation.sample_maxwell_boltzmann(
-                self.beta.repeat_interleave(self.n_atoms),
-                self.initial_data[MASS_KEY],
-            ).to(
-                self.dtype
+            self.initial_data[VELOCITY_KEY] = (
+                LangevinSimulation.sample_maxwell_boltzmann(
+                    self.beta.repeat_interleave(self.n_atoms),
+                    self.initial_data[MASS_KEY],
+                ).to(self.dtype)
             )
         assert (
             self.initial_data[VELOCITY_KEY].shape

--- a/mlcg/simulation/langevin.py
+++ b/mlcg/simulation/langevin.py
@@ -214,7 +214,7 @@ class LangevinSimulation(_Simulation):
         v_new = data[VELOCITY_KEY].view(-1, self.n_atoms, self.n_dims)
         masses = data.masses.view(self.n_sims, self.n_atoms)
 
-        save_ind = t // self.save_interval
+        save_ind = (t // self.save_interval) - self._npy_file_index * self._save_size
 
         if self.save_energies:
             kes = 0.5 * torch.sum(
@@ -222,13 +222,11 @@ class LangevinSimulation(_Simulation):
             )
             self.simulated_kinetic_energies[save_ind, :] = kes
 
-    def write(self, iter_: int):
+    def write(self):
         """Utility to save numpy arrays"""
         key = self._get_numpy_count()
         if self.save_energies:
-            kinetic_energies_to_export = self.simulated_kinetic_energies[
-                self._npy_starting_index : iter_
-            ]
+            kinetic_energies_to_export = self.simulated_kinetic_energies
             kinetic_energies_to_export = self._swap_and_export(
                 kinetic_energies_to_export
             )
@@ -237,7 +235,12 @@ class LangevinSimulation(_Simulation):
                 kinetic_energies_to_export,
             )
 
-        super().write(iter_)
+            # Reset simulate_kinetic_energies
+            self.simulated_kinetic_energies = torch.zeros(
+                self._save_size, self.n_sims
+            )
+
+        super().write()
 
     def reshape_output(self):
         super().reshape_output()

--- a/mlcg/simulation/langevin.py
+++ b/mlcg/simulation/langevin.py
@@ -158,11 +158,13 @@ class LangevinSimulation(_Simulation):
         # Initialize velocities according to Maxwell-Boltzmann distribution
         if VELOCITY_KEY not in self.initial_data:
             # initialize velocities at zero
-            self.initial_data[VELOCITY_KEY] = (
-                LangevinSimulation.sample_maxwell_boltzmann(
-                    self.beta.repeat_interleave(self.n_atoms),
-                    self.initial_data[MASS_KEY],
-                ).to(self.dtype)
+            self.initial_data[
+                VELOCITY_KEY
+            ] = LangevinSimulation.sample_maxwell_boltzmann(
+                self.beta.repeat_interleave(self.n_atoms),
+                self.initial_data[MASS_KEY],
+            ).to(
+                self.dtype
             )
         assert (
             self.initial_data[VELOCITY_KEY].shape
@@ -214,7 +216,9 @@ class LangevinSimulation(_Simulation):
         v_new = data[VELOCITY_KEY].view(-1, self.n_atoms, self.n_dims)
         masses = data.masses.view(self.n_sims, self.n_atoms)
 
-        save_ind = (t // self.save_interval) - self._npy_file_index * self._save_size
+        save_ind = (
+            t // self.save_interval
+        ) - self._npy_file_index * self._save_size
 
         if self.save_energies:
             kes = 0.5 * torch.sum(

--- a/mlcg/simulation/parallel_tempering.py
+++ b/mlcg/simulation/parallel_tempering.py
@@ -146,11 +146,13 @@ class PTSimulation(LangevinSimulation):
 
         else:
             # Initialize velocities according to Maxwell-Boltzmann distribution
-            self.initial_data[VELOCITY_KEY] = (
-                LangevinSimulation.sample_maxwell_boltzmann(
-                    self.beta.repeat_interleave(self.n_atoms),
-                    self.initial_data[MASS_KEY],
-                ).to(self.dtype)
+            self.initial_data[
+                VELOCITY_KEY
+            ] = LangevinSimulation.sample_maxwell_boltzmann(
+                self.beta.repeat_interleave(self.n_atoms),
+                self.initial_data[MASS_KEY],
+            ).to(
+                self.dtype
             )
 
         self.initial_data[MASS_KEY] = self.initial_data[MASS_KEY].to(self.dtype)
@@ -222,11 +224,13 @@ class PTSimulation(LangevinSimulation):
         self.n_dims = new_configurations[0].pos.shape[1]
 
         # Initialize velocities according to Maxwell-Boltzmann distribution
-        self.initial_data[VELOCITY_KEY] = (
-            LangevinSimulation.sample_maxwell_boltzmann(
-                self.beta.repeat_interleave(self.n_atoms),
-                self.initial_data[MASS_KEY],
-            ).to(self.dtype)
+        self.initial_data[
+            VELOCITY_KEY
+        ] = LangevinSimulation.sample_maxwell_boltzmann(
+            self.beta.repeat_interleave(self.n_atoms),
+            self.initial_data[MASS_KEY],
+        ).to(
+            self.dtype
         )
 
         self.initial_data[MASS_KEY] = self.initial_data[MASS_KEY].to(self.dtype)

--- a/mlcg/simulation/parallel_tempering.py
+++ b/mlcg/simulation/parallel_tempering.py
@@ -146,15 +146,12 @@ class PTSimulation(LangevinSimulation):
 
         else:
             # Initialize velocities according to Maxwell-Boltzmann distribution
-            self.initial_data[
-                VELOCITY_KEY
-            ] = LangevinSimulation.sample_maxwell_boltzmann(
-                self.beta.repeat_interleave(self.n_atoms),
-                self.initial_data[MASS_KEY],
-            ).to(
-                self.dtype
+            self.initial_data[VELOCITY_KEY] = (
+                LangevinSimulation.sample_maxwell_boltzmann(
+                    self.beta.repeat_interleave(self.n_atoms),
+                    self.initial_data[MASS_KEY],
+                ).to(self.dtype)
             )
-
         self.initial_data[MASS_KEY] = self.initial_data[MASS_KEY].to(self.dtype)
         self.initial_data[POSITIONS_KEY] = self.initial_data[POSITIONS_KEY].to(
             self.dtype
@@ -224,13 +221,11 @@ class PTSimulation(LangevinSimulation):
         self.n_dims = new_configurations[0].pos.shape[1]
 
         # Initialize velocities according to Maxwell-Boltzmann distribution
-        self.initial_data[
-            VELOCITY_KEY
-        ] = LangevinSimulation.sample_maxwell_boltzmann(
-            self.beta.repeat_interleave(self.n_atoms),
-            self.initial_data[MASS_KEY],
-        ).to(
-            self.dtype
+        self.initial_data[VELOCITY_KEY] = (
+            LangevinSimulation.sample_maxwell_boltzmann(
+                self.beta.repeat_interleave(self.n_atoms),
+                self.initial_data[MASS_KEY],
+            ).to(self.dtype)
         )
 
         self.initial_data[MASS_KEY] = self.initial_data[MASS_KEY].to(self.dtype)


### PR DESCRIPTION
# PR Checklist

- [x] Bug fix
- [x] Black formatting

---

In the current version of MLCG, whenever a simulation is started, for each saved feature (coordinates, forces, energies...), a torch tensor was initialized that could contain the entire simulation. This is using up a lot of RAM we don't need since we export the simulation regularly and never need the full simulation data. 
The modifications included in this PR are inside the simulation class:
- `self.simulated_{coords, forces, potential, kinetic_energies}` now only contain as much data points as needed before the next export
- After each export, these arrays are re-initialized to contain only zeros. 

As a consequence of this, two additional changes have been made for keeping the code consistent:
- the `write()` method now only takes `self` as an argument, `iter_` was removed because only needed to get the indices of the arrays to be saved, but now the entire array is saved by definition
- the `simulate()` method now does not return the full coordinates anymore since `self.simulated_coords` now only contains the last batch before export (or only zeros if export just happened). If people were outputting the total simulation coords after the simulation, eg by `coords = simulation.simulate()`, they will now have `coords = None` and will have to reload the coords from the exported numpy files in their pipelines. This might break a few pipelines but I think it's safer having a pipeline break because of `coords = None` than having a pipeline that runs but is wrong because `coords` doesn't contain the right data anymore.
- `self._npy_starting_index` is no longer used so it was removed completely
