### PR TITLE
fixed bug in initial velocities

### DIFF
--- a/mlcg/simulation/base.py
+++ b/mlcg/simulation/base.py
@@ -41,7 +41,7 @@ class _Simulation(object):
     save_forces : bool, default=False
         Whether to save forces at the same saved interval as the simulation
         coordinates
-    save_potential : bool, default=False
+    save_energies : bool, default=False
         Whether to save potential at the same saved interval as the simulation
         coordinates
     create_checkpoints: bool, default=False
@@ -65,7 +65,7 @@ class _Simulation(object):
         the int specifies at what intervals numpy files will be saved per
         observable. This number must be an integer multiple of save_interval.
         All output files should be the same shape. Forces and potentials will
-        also be saved according to the save_forces and save_potential
+        also be saved according to the save_forces and save_energies
         arguments, respectively. If friction is not None, kinetic energies
         will also be saved. This method is only implemented for a maximum of
         1000 files per observable due to file naming conventions.

--- a/mlcg/simulation/langevin.py
+++ b/mlcg/simulation/langevin.py
@@ -87,7 +87,7 @@ class LangevinSimulation(_Simulation):
             Them masses of each atom
         """
         assert all([m > 0 for m in masses])
-        scale = torch.sqrt(1/(betas*masses))
+        scale = torch.sqrt(1 / (betas * masses))
         dist = Normal(loc=0.00, scale=scale)
         velocities = dist.sample((3,)).t()
         return velocities

--- a/mlcg/simulation/langevin.py
+++ b/mlcg/simulation/langevin.py
@@ -87,7 +87,7 @@ class LangevinSimulation(_Simulation):
             Them masses of each atom
         """
         assert all([m > 0 for m in masses])
-        scale = torch.sqrt(betas / masses)
+        scale = torch.sqrt(1/(betas*masses))
         dist = Normal(loc=0.00, scale=scale)
         velocities = dist.sample((3,)).t()
         return velocities

--- a/mlcg/simulation/test_simulation.py
+++ b/mlcg/simulation/test_simulation.py
@@ -448,8 +448,8 @@ def test_maxwell_boltzmann_stats():
         (sampled_velocities**2).sum(dim=1)
     ).mean()
     emperical_expectation_2 = (sampled_velocities**2).sum(dim=1).mean()
-    theory_expectation = torch.sqrt(8 * betas[0] / (torch_pi * masses[0]))
-    theory_expectation_2 = 3 * betas[0] / (masses[0])
+    theory_expectation = torch.sqrt(8/(torch_pi*betas[0]*masses[0]))
+    theory_expectation_2 = 3/(betas[0]*masses[0])
 
     np.testing.assert_almost_equal(
         emperical_expectation.numpy(), theory_expectation.numpy(), decimal=2
@@ -484,8 +484,8 @@ def test_pt_velocity_init(tmp_path):
 
     mass = 1.00
     for i, beta in enumerate(betas):
-        theory_expectation = torch.sqrt(8 * beta / (torch_pi * mass))
-        theory_expectation_2 = torch.tensor(3 * beta / (mass))
+        theory_expectation = torch.sqrt(8/(beta*torch_pi*mass))
+        theory_expectation_2 = torch.tensor(3/(beta*mass))
 
         velocities = simulation.initial_data.velocities[
             (n_indep * n_atoms) * i : (n_indep * n_atoms) * (i + 1)

--- a/mlcg/simulation/test_simulation.py
+++ b/mlcg/simulation/test_simulation.py
@@ -448,8 +448,8 @@ def test_maxwell_boltzmann_stats():
         (sampled_velocities**2).sum(dim=1)
     ).mean()
     emperical_expectation_2 = (sampled_velocities**2).sum(dim=1).mean()
-    theory_expectation = torch.sqrt(8/(torch_pi*betas[0]*masses[0]))
-    theory_expectation_2 = 3/(betas[0]*masses[0])
+    theory_expectation = torch.sqrt(8 / (torch_pi * betas[0] * masses[0]))
+    theory_expectation_2 = 3 / (betas[0] * masses[0])
 
     np.testing.assert_almost_equal(
         emperical_expectation.numpy(), theory_expectation.numpy(), decimal=2
@@ -484,8 +484,8 @@ def test_pt_velocity_init(tmp_path):
 
     mass = 1.00
     for i, beta in enumerate(betas):
-        theory_expectation = torch.sqrt(8/(beta*torch_pi*mass))
-        theory_expectation_2 = torch.tensor(3/(beta*mass))
+        theory_expectation = torch.sqrt(8 / (beta * torch_pi * mass))
+        theory_expectation_2 = torch.tensor(3 / (beta * mass))
 
         velocities = simulation.initial_data.velocities[
             (n_indep * n_atoms) * i : (n_indep * n_atoms) * (i + 1)


### PR DESCRIPTION
# PR Checklist

- [x] Bug fix
- [] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

### Describe your changes here:
The sigma of the Boltzmann distribution used to generate the initial velocities was not correct.
The non-correct/previous sigma was: sqrt(beta/m).
The current/correct sigma is: sqrt(1/(beta*m))
