### PR TITLE
Improve docs about timestep units

### DIFF
--- a/docs/source/bibliography.rst
+++ b/docs/source/bibliography.rst
@@ -12,7 +12,7 @@ Dataset & Simulation References
 
 .. [TIP3P] Jorgensen, W.L. et al. `Comparison of simple potential functions for simulating water <https://aip.scitation.org/doi/10.1063/1.445869>`_ . J. Chem. Phys. 926(79). (1983).
 
-.. [CHARM22Star] Piana, S., et al. `How Robust Are Protein Folding Simulations with Respect to Force Field Parameterization? <https://doi.org/10.1016/j.bpj.2011.03.051>`_ Biophys J. 100. 47-49. (2001).
+.. [CHARM22Star] Piana, S., et al. `How Robust Are Protein Folding Simulations with Respect to Force Field Parameterization? <https://doi.org/10.1016/j.bpj.2011.03.051>`_ . Biophys J. 100. 47-49. (2001).
 
 .. [AMBER_ff_99SB_ILDN] Hornak, V. et al. `Comparison of multiple Amber force fields and development of improved protein backbone parameters <https://onlinelibrary.wiley.com/doi/10.1002/prot.21123>`_ . Proteins: Structure, Function, and Bioinformatics, 65(3), 712–725. (2006).
 
@@ -30,10 +30,17 @@ CGnet References
 
 Neural Network Architectures & Implementations
 ----------------------------------------------
-.. [Schnet] Schütt, K. T. et al. `SchNet – A deep learning architecture for molecules and materials <https://doi.org/10.1063/1.5019779>`_ J. Chem. Phys. 148(24), 241722. (2018).
+.. [Schnet] Schütt, K. T. et al. `SchNet – A deep learning architecture for molecules and materials <https://doi.org/10.1063/1.5019779>`_ . J. Chem. Phys. 148(24), 241722. (2018).
 
 .. [PT_geom_schnet] https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/nn/models/schnet.html
 
-.. [Physnet] Unke, O. T. et al. `PhysNet: A Neural Network for Predicting Energies, Forces, Dipole Moments and Partial Charges. <https://doi.org/10.1021/acs.jctc.9b00181>`_ Journal of Chemical Theory and Computation, 15(6). 3678–3693. (2019).
+.. [Physnet] Unke, O. T. et al. `PhysNet: A Neural Network for Predicting Energies, Forces, Dipole Moments and Partial Charges. <https://doi.org/10.1021/acs.jctc.9b00181>`_ . Journal of Chemical Theory and Computation, 15(6). 3678–3693. (2019).
 
-.. [MACE] Batatia, I. et al. `MACE: Higher Order Equivariant Message Passing Neural Networks for Fast and Accurate Force Fields <https://proceedings.neurips.cc/paper_files/paper/2022/hash/4a36c3c51af11ed9f34615b81edb5bbc-Abstract-Conference.html>`_  Advances in Neural Information Processing Systems, 35. 11423-11436 (2022)
+.. [MACE] Batatia, I. et al. `MACE: Higher Order Equivariant Message Passing Neural Networks for Fast and Accurate Force Fields <https://proceedings.neurips.cc/paper_files/paper/2022/hash/4a36c3c51af11ed9f34615b81edb5bbc-Abstract-Conference.html>`_ . Advances in Neural Information Processing Systems, 35. 11423-11436 (2022)
+
+Langevin Dynamics and Integrators
+---------------------------------
+
+.. [BAOAB] Leimkuhler, B. and Matthews, C. `Rational Construction of Stochastic Numerical Methods for Molecular Sampling <https://doi.org/10.1093/amrx/abs010>`_ . Applied Mathematics Research eXpress, 2013(1), 34-56. (2013)
+
+.. [MDBook] Leimkuhler, B. and Matthews, C. `Molecular Dynamics <https://link.springer.com/book/10.1007/978-3-319-16375-8>`_ .Interdisciplinary Applied Mathematics 39,  Springer. (2015, Section 7.3.1 *Splitting Methods For Langevin Dynamics*)

--- a/mlcg/simulation/base.py
+++ b/mlcg/simulation/base.py
@@ -38,17 +38,17 @@ class _Simulation(object):
     ----------
     dt : float, default=5e-4
         The integration time step for the dynamics. The simulation code is unit agnostic
-        and will use the same distance and energy units that the network and initial configurations. 
+        and will use the same distance and energy units that the network and initial configurations.
         However, for the two other parameters in a simulation, time and mass, only one of them is unit-agnostic:
         **if you provide the time thinking in a particular unit, the unit of mass is defined, and
         viceversa. Be aware that only either mass or time can be provided in custom units**.
-        
-        The following relation must be satisfied by the units to ensure consistency: 
+
+        The following relation must be satisfied by the units to ensure consistency:
 
         .. math::
 
             [\text{Energy}] = [\text{Mass}]\frac{[\text{Length}]^2}{[\text{Time}]^2}
-        
+
         For example, if you are using kcal/mol for the energy, Angstrom from the distance and time
         in picoseconds, the masses will need to be provided in units of AMU/418.39.
     save_forces : bool, default=False

--- a/mlcg/simulation/base.py
+++ b/mlcg/simulation/base.py
@@ -34,10 +34,15 @@ JPERKCAL = 4184  # Ratio of Joules/kilocalorie
 
 class _Simulation(object):
     """
+
     Parameters
     ----------
     dt : float, default=5e-4
-        The integration time step for Langevin dynamics.
+        The integration time step for Langevin dynamics. The simulation code is unit agnostic
+        and will use the distance and energy units that are used by the network. However, from
+        the two  other parameters in a simulation, time and mass, only one of them is unit-agnostic:
+        **if you provide the time thinking in a particular unit, the unit of mass is defined, and
+        viceversa. Please be aware that only either mass or time can be provided in custom units**.
     save_forces : bool, default=False
         Whether to save forces at the same saved interval as the simulation
         coordinates

--- a/mlcg/simulation/base.py
+++ b/mlcg/simulation/base.py
@@ -33,16 +33,24 @@ JPERKCAL = 4184  # Ratio of Joules/kilocalorie
 
 
 class _Simulation(object):
-    """
-
+    r"""
     Parameters
     ----------
     dt : float, default=5e-4
-        The integration time step for Langevin dynamics. The simulation code is unit agnostic
-        and will use the distance and energy units that are used by the network. However, from
-        the two  other parameters in a simulation, time and mass, only one of them is unit-agnostic:
+        The integration time step for the dynamics. The simulation code is unit agnostic
+        and will use the same distance and energy units that the network and initial configurations. 
+        However, for the two other parameters in a simulation, time and mass, only one of them is unit-agnostic:
         **if you provide the time thinking in a particular unit, the unit of mass is defined, and
-        viceversa. Please be aware that only either mass or time can be provided in custom units**.
+        viceversa. Be aware that only either mass or time can be provided in custom units**.
+        
+        The following relation must be satisfied by the units to ensure consistency: 
+
+        .. math::
+
+            [\text{Energy}] = [\text{Mass}]\frac{[\text{Length}]^2}{[\text{Time}]^2}
+        
+        For example, if you are using kcal/mol for the energy, Angstrom from the distance and time
+        in picoseconds, the masses will need to be provided in units of AMU/418.39.
     save_forces : bool, default=False
         Whether to save forces at the same saved interval as the simulation
         coordinates
@@ -62,7 +70,7 @@ class _Simulation(object):
         Seed for random number generator; if seeded, results always will be
         identical for the same random seed
     device : str, default='cpu'
-        Device upon which simulation compuation will be carried out
+        Device upon which simulation computation will be carried out
     dtype : str, default='single'
         precision to run the simulation with (single or double)
     export_interval : int, default=None

--- a/mlcg/simulation/langevin.py
+++ b/mlcg/simulation/langevin.py
@@ -18,9 +18,9 @@ torch_pi = torch.tensor(np.pi)
 
 
 class LangevinSimulation(_Simulation):
-    r"""Langevin simulatin class for trained models.
+    r"""Langevin simulation class for trained models.
 
-    The following `BAOAB integration scheme <https://doi.org/10.1007/978-3-319-16375-8>`_ is used, where::
+    The following [BAOAB]_ integration scheme is used, where::
 
         B = deterministic velocity update
         A = deterministic position update
@@ -46,7 +46,7 @@ class LangevinSimulation(_Simulation):
         \epsilon =& \exp(-\eta \; \Delta t) \\
         & \\
         \alpha =& \sqrt{(1 - \epsilon^2) / \beta m}
-
+    
     Initial velocities are sampled from the Maxwell-Boltzmann distribution for 
     the provided beta.
 
@@ -56,6 +56,8 @@ class LangevinSimulation(_Simulation):
     .. math::
         D = 1 / (\beta  \eta)
     
+    For a larger discussion on Langevin Dynamics integrators, please refer to [MDBook]_.
+        
     Parameters
     ----------
 
@@ -266,7 +268,7 @@ class LangevinSimulation(_Simulation):
 
 # pipe the doc from the base class into the child class so that it's properly
 # displayed by sphinx
-LangevinSimulation.__doc__ += _Simulation.__doc__
+LangevinSimulation.__doc__ += _Simulation.__doc__ + "\n"
 
 
 class OverdampedSimulation(_Simulation):
@@ -280,6 +282,9 @@ class OverdampedSimulation(_Simulation):
     for coordinates :math:`X_t` at time :math:`t`, potential energy :math:`U`,
     diffusion :math:`D`, thermodynamic inverse temperature :math:`\beta`,
     time step :math:`\Delta t`, and stochastic Weiner process :math:`W`.
+
+    Due to the nature of Overdamped Langevin dynamics, the masses and velocities 
+    are not used.
 
     Parameters
     ----------

--- a/mlcg/simulation/langevin.py
+++ b/mlcg/simulation/langevin.py
@@ -283,7 +283,7 @@ class OverdampedSimulation(_Simulation):
     diffusion :math:`D`, thermodynamic inverse temperature :math:`\beta`,
     time step :math:`\Delta t`, and stochastic Weiner process :math:`W`.
 
-    Due to the nature of Overdamped Langevin dynamics, the masses and velocities 
+    Due to the nature of Overdamped Langevin dynamics, the masses and velocities
     are not used.
 
     Parameters

--- a/mlcg/simulation/langevin.py
+++ b/mlcg/simulation/langevin.py
@@ -161,13 +161,11 @@ class LangevinSimulation(_Simulation):
         # Initialize velocities according to Maxwell-Boltzmann distribution
         if VELOCITY_KEY not in self.initial_data:
             # initialize velocities at zero
-            self.initial_data[
-                VELOCITY_KEY
-            ] = LangevinSimulation.sample_maxwell_boltzmann(
-                self.beta.repeat_interleave(self.n_atoms),
-                self.initial_data[MASS_KEY],
-            ).to(
-                self.dtype
+            self.initial_data[VELOCITY_KEY] = (
+                LangevinSimulation.sample_maxwell_boltzmann(
+                    self.beta.repeat_interleave(self.n_atoms),
+                    self.initial_data[MASS_KEY],
+                ).to(self.dtype)
             )
         assert (
             self.initial_data[VELOCITY_KEY].shape

--- a/mlcg/simulation/parallel_tempering.py
+++ b/mlcg/simulation/parallel_tempering.py
@@ -146,11 +146,13 @@ class PTSimulation(LangevinSimulation):
 
         else:
             # Initialize velocities according to Maxwell-Boltzmann distribution
-            self.initial_data[VELOCITY_KEY] = (
-                LangevinSimulation.sample_maxwell_boltzmann(
-                    self.beta.repeat_interleave(self.n_atoms),
-                    self.initial_data[MASS_KEY],
-                ).to(self.dtype)
+            self.initial_data[
+                VELOCITY_KEY
+            ] = LangevinSimulation.sample_maxwell_boltzmann(
+                self.beta.repeat_interleave(self.n_atoms),
+                self.initial_data[MASS_KEY],
+            ).to(
+                self.dtype
             )
         self.initial_data[MASS_KEY] = self.initial_data[MASS_KEY].to(self.dtype)
         self.initial_data[POSITIONS_KEY] = self.initial_data[POSITIONS_KEY].to(
@@ -221,11 +223,13 @@ class PTSimulation(LangevinSimulation):
         self.n_dims = new_configurations[0].pos.shape[1]
 
         # Initialize velocities according to Maxwell-Boltzmann distribution
-        self.initial_data[VELOCITY_KEY] = (
-            LangevinSimulation.sample_maxwell_boltzmann(
-                self.beta.repeat_interleave(self.n_atoms),
-                self.initial_data[MASS_KEY],
-            ).to(self.dtype)
+        self.initial_data[
+            VELOCITY_KEY
+        ] = LangevinSimulation.sample_maxwell_boltzmann(
+            self.beta.repeat_interleave(self.n_atoms),
+            self.initial_data[MASS_KEY],
+        ).to(
+            self.dtype
         )
         self.initial_data[MASS_KEY] = self.initial_data[MASS_KEY].to(self.dtype)
         self.initial_data[POSITIONS_KEY] = self.initial_data[POSITIONS_KEY].to(

--- a/mlcg/simulation/parallel_tempering.py
+++ b/mlcg/simulation/parallel_tempering.py
@@ -146,13 +146,11 @@ class PTSimulation(LangevinSimulation):
 
         else:
             # Initialize velocities according to Maxwell-Boltzmann distribution
-            self.initial_data[
-                VELOCITY_KEY
-            ] = LangevinSimulation.sample_maxwell_boltzmann(
-                self.beta.repeat_interleave(self.n_atoms),
-                self.initial_data[MASS_KEY],
-            ).to(
-                self.dtype
+            self.initial_data[VELOCITY_KEY] = (
+                LangevinSimulation.sample_maxwell_boltzmann(
+                    self.beta.repeat_interleave(self.n_atoms),
+                    self.initial_data[MASS_KEY],
+                ).to(self.dtype)
             )
         self.initial_data[MASS_KEY] = self.initial_data[MASS_KEY].to(self.dtype)
         self.initial_data[POSITIONS_KEY] = self.initial_data[POSITIONS_KEY].to(
@@ -223,13 +221,11 @@ class PTSimulation(LangevinSimulation):
         self.n_dims = new_configurations[0].pos.shape[1]
 
         # Initialize velocities according to Maxwell-Boltzmann distribution
-        self.initial_data[
-            VELOCITY_KEY
-        ] = LangevinSimulation.sample_maxwell_boltzmann(
-            self.beta.repeat_interleave(self.n_atoms),
-            self.initial_data[MASS_KEY],
-        ).to(
-            self.dtype
+        self.initial_data[VELOCITY_KEY] = (
+            LangevinSimulation.sample_maxwell_boltzmann(
+                self.beta.repeat_interleave(self.n_atoms),
+                self.initial_data[MASS_KEY],
+            ).to(self.dtype)
         )
         self.initial_data[MASS_KEY] = self.initial_data[MASS_KEY].to(self.dtype)
         self.initial_data[POSITIONS_KEY] = self.initial_data[POSITIONS_KEY].to(


### PR DESCRIPTION
# PR Checklist

- [] Bug fix
- [] Feature addition/change
- [x] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

### Describe your changes here:

Although the simulation code is unit agnostic, the units of time and mass are not independent of each other. As the code is used for more applications, it is important that the documentation takes note in this.

I've made more explicit in the doc string of the simulation class than there is a coupling between the mass and time units and that the user should be aware of this when running a simulation. 
