### PR TITLE
seed warning for distributed workflows

### DIFF
--- a/mlcg/pl/cli.py
+++ b/mlcg/pl/cli.py
@@ -33,18 +33,30 @@ class LightningCLI(plc.LightningCLI):
         else:
             config = self.config
 
-        if self.config["seed_everything"] in (None, False):
-            devices = self.config["trainer"]["devices"]
-            num_nodes = self.config["trainer"]["num_nodes"]
+        if config["seed_everything"] in (None, False):
+            devices = int(config["trainer"]["devices"])
+            num_nodes = int(config["trainer"]["num_nodes"])
             if (
-                self.config["trainer"]["gpus"] is not None
+                config["trainer"]["gpus"] is not None
             ):  # account for composite/redundant lightning trainer opts
-                gpus = self.config["gpus"]
+                gpus = config["trainer"]["gpus"]
                 if isinstance(gpus, list):
                     gpus = len(gpus)
             if (num_nodes > 1) or (devices > 1) or (gpus > 1):
                 warnings.warn(
-                    "ATTENTION: `seed_everything` has been set to false/null, but multiple devices are being used for distributed training. This can result in local ranks/procids making different train/val/test data splits, which can further result in train/val/test data leakage. Please follow the best practice as outlined by Lightning developers and set `seed_everything` to a non-zero integer for multi-device computations. Else, make sure that your `PLDataModule` avoids this be defining the splits to loaded from the disk beforehand."
+                    " \n \n ###################################################### \n"
+                    "           WARNING: Possible data leakage  \n "
+                    "######################################################  \n \n "
+                    "`seed_everything` has been set to false/null, but multiple "
+                    "devices are being used for distributed training. This can result in "
+                    "local ranks/procids making different train/val/test data splits, which "
+                    "can further result in train/val/test data leakage. Please follow the "
+                    "best practice as outlined by Lightning developers and set "
+                    "`seed_everything` to a non-zero integer for multi-device "
+                    "computations. Else, make sure that your `PLDataModule` "
+                    "avoids this be defining the splits to loaded from "
+                    "the disk beforehand. "
+                    "\n \n ###################################################### \n \n "
                 )
 
         trainer = config["trainer"]

--- a/mlcg/pl/cli.py
+++ b/mlcg/pl/cli.py
@@ -33,16 +33,20 @@ class LightningCLI(plc.LightningCLI):
         else:
             config = self.config
 
-        if self.config["seed_everything"] is in (None, False):
+        if self.config["seed_everything"] in (None, False):
             devices = self.config["trainer"]["devices"]
             num_nodes = self.config["trainer"]["num_nodes"]
-            if self.config["trainer"]['gpus'] is not None: # account for composite/redundant lightning trainer opts 
+            if (
+                self.config["trainer"]["gpus"] is not None
+            ):  # account for composite/redundant lightning trainer opts
                 gpus = self.config["gpus"]
                 if isinstance(gpus, list):
                     gpus = len(gpus)
             if (num_nodes > 1) or (devices > 1) or (gpus > 1):
-                warnings.warn("ATTENTION: `seed_everything` has been set to false/null, but multiple devices are being used for distributed training. This can result in local ranks/procids making different train/val/test data splits, which can further result in train/val/test data leakage. Please follow the best practice as outlined by Lightning developers and set `seed_everything` to a non-zero integer for multi-device computations. Else, make sure that your `PLDataModule` avoids this be defining the splits to loaded from the disk beforehand.")
-        
+                warnings.warn(
+                    "ATTENTION: `seed_everything` has been set to false/null, but multiple devices are being used for distributed training. This can result in local ranks/procids making different train/val/test data splits, which can further result in train/val/test data leakage. Please follow the best practice as outlined by Lightning developers and set `seed_everything` to a non-zero integer for multi-device computations. Else, make sure that your `PLDataModule` avoids this be defining the splits to loaded from the disk beforehand."
+                )
+
         trainer = config["trainer"]
         default_root_dir = trainer.get("default_root_dir")
         if default_root_dir is not None:

--- a/mlcg/pl/cli.py
+++ b/mlcg/pl/cli.py
@@ -3,6 +3,7 @@ import torch
 import pytorch_lightning.cli as plc
 from torch_geometric.data.makedirs import makedirs
 import torch_optimizer as optim
+import warnings
 
 
 class LightningCLI(plc.LightningCLI):
@@ -32,6 +33,16 @@ class LightningCLI(plc.LightningCLI):
         else:
             config = self.config
 
+        if self.config["seed_everything"] is in (None, False):
+            devices = self.config["trainer"]["devices"]
+            num_nodes = self.config["trainer"]["num_nodes"]
+            if self.config["trainer"]['gpus'] is not None: # account for composite/redundant lightning trainer opts 
+                gpus = self.config["gpus"]
+                if isinstance(gpus, list):
+                    gpus = len(gpus)
+            if (num_nodes > 1) or (devices > 1) or (gpus > 1):
+                warnings.warn("ATTENTION: `seed_everything` has been set to false/null, but multiple devices are being used for distributed training. This can result in local ranks/procids making different train/val/test data splits, which can further result in train/val/test data leakage. Please follow the best practice as outlined by Lightning developers and set `seed_everything` to a non-zero integer for multi-device computations. Else, make sure that your `PLDataModule` avoids this be defining the splits to loaded from the disk beforehand.")
+        
         trainer = config["trainer"]
         default_root_dir = trainer.get("default_root_dir")
         if default_root_dir is not None:


### PR DESCRIPTION
# PR Checklist

- [] Bug fix
- [x] Feature addition/change
- [x] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

Hello. This PR adds a warning when users are setting `seed_everything` to `false`/`null` in configs for distributed workflows. Seems that this sort of a hidden corner issue/pain with PyTorch Lightning, as the official `LightningDataModule` docs/examples fail to underscore the following issue:

```
The `setup()` method is called per rank/procid. This means that for DDP, the whole dataset is sent to each GPU/device (on each node if there is multinode training) and they can run their own (self-seeded) random number generators when making data splits if `seed_everything` is set to `false`/`null`. Effectively, this will lead to unintentional data leakage between train/val/test sets if the user does not read any predetermined splits from disk.
```

I have tested this on a single node (all I have access to at the moment) with 4 A100s. I can confirm that for the `ChignolinDataset` example, if `seed_everything` is set properly (ie, any positive integer), each rank/procid splits the data into the same train/test/val partitions properly. However, if `seed_everything` is set to `false`/`null`, this is no longer true. Also it should be noted that, while if completely unspecified, `seed_everything` defaults to the integer value `0`, nothing prevents a user with alternative intuition from setting it to `null`/`false` in the config and leading themselves to this issue.

This issue was brought up in the recent-ish past with the Lightning developers, and they acknowledged the potential issue but basically say "always set `seed_everything` for distributed workflows, or predefine the splits and load them from disk" (also an option we provide with `mlcg`). Just as well, `prepare_data` is not so helpful here because its not intended to be used for setting state. See here to unwrap my paraphrasing: https://github.com/Lightning-AI/pytorch-lightning/issues/18638

In the end, I have opted to follow the Lightning devs thinking and just add a warning to alert users who may hit this corner case, as setting `seed_everything` seems to solve this potential issue.

A couple questions:

1. Is a simple warning enough (eg, warning fatigue with all the other stock torch/pl warnings)?
2. Right now the warning is only for the cli training. Is it necessary to go beyond this? I'm not sure if anyone is using non-cli Lightning pipelines with `mlcg` atm.

Still have to check a few things but happy for feedback.

✌️ 
