### PR TITLE
removed gradient computation on model parameters + detached forces

### DIFF
--- a/mlcg/simulation/base.py
+++ b/mlcg/simulation/base.py
@@ -211,6 +211,8 @@ class _Simulation(object):
             Trained model used to generate simulation data
         """
         self.model = model.eval().to(device=self.device, dtype=self.dtype)
+        for param in self.model.parameters():
+            param.requires_grad = False
 
     def _attach_configurations(
         self,
@@ -411,7 +413,7 @@ class _Simulation(object):
 
         data = self.model(data)
         potential = data.out[ENERGY_KEY].detach()
-        forces = data.out[FORCE_KEY]
+        forces = data.out[FORCE_KEY].detach()
         return potential, forces
 
     def timestep(self):


### PR DESCRIPTION
# PR Checklist

- [x] Bug fix
- [x] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

### Describe your changes here:
During simulation on model parameters gradient computation is deactivated as not needed.
Forces are detached after being computed by the model as done for the potential. This could lead to memory issues if higher-order derivatives were to be computed on the model, since gradients would be accumulated throughout the entire trajectory, quickly resulting in abnormal GPU memory usage