### PR TITLE
PT relaunch puts wrong initial positions it  the prior is not specialized.

### DIFF
--- a/mlcg/simulation/test_simulation.py
+++ b/mlcg/simulation/test_simulation.py
@@ -337,7 +337,7 @@ def test_exchange_detection(tmp_path):
         simulation.initial_data["out"]["energy"] = torch.tensor(
             [low_energy, low_energy, high_energy, high_energy]
         )
-        for _ in range(1000):
+        for _ in range(2000):
             simulation._detect_exchange(simulation.initial_data)
         empirical_rate = (
             simulation._replica_exchange_approved


### PR DESCRIPTION
# PR Checklist

- [x] Bug fix
- [] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

### Describe your changes here:

When relaunching a PT simulation from a checkpoint, `PTsimulation.attach_model_and_configurations` only takes the initial positions from the checkpoint when `self. specialize_priors`  is set to true and the `PTsimulation._manually_reattach_configurations` is called. Otherwise, the call goes to `_attach_configurations` and the checkpoint positions are not used. 

This PR should change and fix this behaviour. I also added further iterations to the `test_exchange_detection` test to avoid failures.
