### PR TITLE
fixed name of PT simulation script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ mlcg-combine_model = "mlcg.scripts.mlcg_combine_model:main"
 mlcg-train_h5 = "mlcg.scripts.mlcg_train_h5:main"
 mlcg-train = "mlcg.scripts.mlcg_train:main"
 mlcg-nvt_langevin = "mlcg.scripts.mlcg_nvt_langevin:main"
-mlcg-nvt_pt_langevin = "mlcg.scripts.mlcg_pt_nvt_langevin:main"
+mlcg-nvt_pt_langevin = "mlcg.scripts.mlcg_nvt_pt_langevin:main"
 
 [tool.black]
 line-length = 80


### PR DESCRIPTION
# PR Checklist

- [x] Bug fix

---

### Describe your changes here:
The name of the PT simulation file was changed in pyproject.toml. 
Indeed, launching PT simulations via `mlcg-nvt_pt_langevin` was resulting in the error `ModuleNotFoundError: No module named 'mlcg.scripts.mlcg_pt_nvt_langevin'`