### PR TITLE
Fix: use right variable for allocating exchange matrix

### DIFF
--- a/src/mlcg/simulation/parallel_tempering.py
+++ b/src/mlcg/simulation/parallel_tempering.py
@@ -103,7 +103,7 @@ class PTSimulation(LangevinSimulation):
     def _set_up_simulation(self, overwrite: bool = False):
         super(PTSimulation, self)._set_up_simulation(overwrite=overwrite)
         self._reset_exchange_stats()
-        self.exchange_arr = torch.zeros((self.n_sims, self._save_size))
+        self.exchange_arr = torch.zeros((self.n_sims, int(self.n_timesteps / self.save_interval)),dtype=torch.int8)
         self.acceptance_matrix = torch.zeros(
             self.n_replicas, self.n_replicas
         ).to(self.device)

--- a/src/mlcg/simulation/parallel_tempering.py
+++ b/src/mlcg/simulation/parallel_tempering.py
@@ -103,7 +103,10 @@ class PTSimulation(LangevinSimulation):
     def _set_up_simulation(self, overwrite: bool = False):
         super(PTSimulation, self)._set_up_simulation(overwrite=overwrite)
         self._reset_exchange_stats()
-        self.exchange_arr = torch.zeros((self.n_sims, int(self.n_timesteps / self.save_interval)),dtype=torch.int8)
+        self.exchange_arr = torch.zeros(
+            (self.n_sims, int(self.n_timesteps / self.save_interval)),
+            dtype=torch.int8,
+        )
         self.acceptance_matrix = torch.zeros(
             self.n_replicas, self.n_replicas
         ).to(self.device)


### PR DESCRIPTION
# PR Checklist

- [x] Bug fix
- [] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

### Describe your changes here:

Main branch currently uses the wrong variable to allocate the size of the exchange matrix in PT. This causes the simulation to crash at the first saving attempt.

This fix uses the right variable to allocate the variable. Tested that the simulation runs and exits saving the right shapes.
.