### PR TITLE
Fix: add None to the list of types to check avoid

### DIFF
--- a/src/mlcg/nn/pyg_forward_compatibility.py
+++ b/src/mlcg/nn/pyg_forward_compatibility.py
@@ -100,7 +100,7 @@ def _search_for_model(
     """Recursively search for model_type in all submodules."""
     if isinstance(top_level, model_type):
         yield top_level
-    elif isinstance(top_level, (int, str, float, torch.Tensor, list)):
+    elif isinstance(top_level, (int, str, float, torch.Tensor, list)) or top_level is None:
         pass
     elif isinstance(top_level, torch.nn.ModuleDict) or isinstance(
         top_level, Mapping

--- a/src/mlcg/nn/pyg_forward_compatibility.py
+++ b/src/mlcg/nn/pyg_forward_compatibility.py
@@ -100,7 +100,10 @@ def _search_for_model(
     """Recursively search for model_type in all submodules."""
     if isinstance(top_level, model_type):
         yield top_level
-    elif isinstance(top_level, (int, str, float, torch.Tensor, list)) or top_level is None:
+    elif (
+        isinstance(top_level, (int, str, float, torch.Tensor, list))
+        or top_level is None
+    ):
         pass
     elif isinstance(top_level, torch.nn.ModuleDict) or isinstance(
         top_level, Mapping


### PR DESCRIPTION
# PR Checklist

- [x] Bug fix
- [] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

### Describe your changes here:

Very old checkpoints have fields that evaluate to None, given the change in lightning version. The `load_and_adapt_old_checkpoint` function doesn't take care of them.

This PR introduces a small change to take this into account. 

