### PR TITLE
own_nl_models parameter added to SumOut

### DIFF
--- a/src/mlcg/nn/gradients.py
+++ b/src/mlcg/nn/gradients.py
@@ -13,6 +13,16 @@ class SumOut(torch.nn.Module):
         Dictionary of predictors models keyed by their name attribute
     targets:
         List of prediction targets that will be pooled
+    dynamic_nl_models:
+        Optional collection of model keys (matching keys in ``models``) whose
+        neighbor list is coordinate-dependent and must be recomputed on every
+        forward call (e.g. a radius-cutoff graph network), rather than reusing
+        the shared/static neighbor list supplied via ``data.neighbor_list``.
+        For these models, ``data.neighbor_list`` is temporarily cleared before
+        the call and restored immediately afterwards, so other models (e.g.
+        bonded priors relying on a fixed topology) are unaffected. Defaults to
+        ``None``, which preserves the previous behavior (no model is treated
+        specially).
 
     Example
     -------
@@ -40,6 +50,15 @@ class SumOut(torch.nn.Module):
                  }
         full_model = SumOut(models, targets=[ENERGY_KEY, FORCE_KEY])
 
+        # If SchNet should rebuild its own (coordinate-dependent) neighbor
+        # list on every call instead of reusing the static one used by the
+        # bonded priors:
+        full_model = SumOut(
+            models,
+            targets=[ENERGY_KEY, FORCE_KEY],
+            dynamic_nl_models=["SchNet"],
+        )
+
 
     """
 
@@ -49,12 +68,16 @@ class SumOut(torch.nn.Module):
         self,
         models: torch.nn.ModuleDict,
         targets: List[str] = None,
+        dynamic_nl_models: Sequence[str] = None,
     ):
         super(SumOut, self).__init__()
         if targets is None:
             targets = [ENERGY_KEY, FORCE_KEY]
         self.targets = targets
         self.models = models
+        self.dynamic_nl_models = (
+            frozenset(dynamic_nl_models) if dynamic_nl_models else frozenset()
+        )
 
     def forward(self, data: AtomicData) -> AtomicData:
         r"""Sums output properties from individual models into global
@@ -110,8 +133,16 @@ class SumOut(torch.nn.Module):
         """
         for target in self.targets:
             data.out[target] = 0.00
+
+        original_neighbor_list = data.neighbor_list if self.dynamic_nl_models else None
+
         for name in self.models.keys():
-            data = self.models[name](data)
+            if name in self.dynamic_nl_models:
+                data.neighbor_list = {}
+                data = self.models[name](data)
+                data.neighbor_list = original_neighbor_list
+            else:
+                data = self.models[name](data)
             for target in self.targets:
                 data.out[target] += data.out[name][target]
         return data

--- a/src/mlcg/nn/gradients.py
+++ b/src/mlcg/nn/gradients.py
@@ -13,16 +13,14 @@ class SumOut(torch.nn.Module):
         Dictionary of predictors models keyed by their name attribute
     targets:
         List of prediction targets that will be pooled
-    dynamic_nl_models:
-        Optional collection of model keys (matching keys in ``models``) whose
-        neighbor list is coordinate-dependent and must be recomputed on every
-        forward call (e.g. a radius-cutoff graph network), rather than reusing
-        the shared/static neighbor list supplied via ``data.neighbor_list``.
-        For these models, ``data.neighbor_list`` is temporarily cleared before
-        the call and restored immediately afterwards, so other models (e.g.
-        bonded priors relying on a fixed topology) are unaffected. Defaults to
-        ``None``, which preserves the previous behavior (no model is treated
-        specially).
+    own_nl_models:
+        Optional model keys that should not receive the shared
+        ``data.neighbor_list``. Useful in cases where a model needs to
+        build its own coordinate-dependent neighbor list and in compilation
+        cases. For each key listed here, ``data.neighbor_list``
+        is temporarily cleared right before that model's call and restored
+        immediately after, leaving the other models unaffected. Defaults to
+        ``None``.
 
     Example
     -------
@@ -50,13 +48,11 @@ class SumOut(torch.nn.Module):
                  }
         full_model = SumOut(models, targets=[ENERGY_KEY, FORCE_KEY])
 
-        # If SchNet should rebuild its own (coordinate-dependent) neighbor
-        # list on every call instead of reusing the static one used by the
-        # bonded priors:
+        # Withhold the shared neighbor_list from SchNet's call:
         full_model = SumOut(
             models,
             targets=[ENERGY_KEY, FORCE_KEY],
-            dynamic_nl_models=["SchNet"],
+            own_nl_models=["SchNet"],
         )
 
 
@@ -68,16 +64,14 @@ class SumOut(torch.nn.Module):
         self,
         models: torch.nn.ModuleDict,
         targets: List[str] = None,
-        dynamic_nl_models: Sequence[str] = None,
+        own_nl_models: Sequence[str] = None,
     ):
         super(SumOut, self).__init__()
         if targets is None:
             targets = [ENERGY_KEY, FORCE_KEY]
         self.targets = targets
         self.models = models
-        self.dynamic_nl_models = (
-            frozenset(dynamic_nl_models) if dynamic_nl_models else frozenset()
-        )
+        self.own_nl_models = frozenset(own_nl_models) if own_nl_models else frozenset()
 
     def forward(self, data: AtomicData) -> AtomicData:
         r"""Sums output properties from individual models into global
@@ -134,10 +128,10 @@ class SumOut(torch.nn.Module):
         for target in self.targets:
             data.out[target] = 0.00
 
-        original_neighbor_list = data.neighbor_list if self.dynamic_nl_models else None
+        original_neighbor_list = data.neighbor_list if self.own_nl_models else None
 
         for name in self.models.keys():
-            if name in self.dynamic_nl_models:
+            if name in self.own_nl_models:
                 data.neighbor_list = {}
                 data = self.models[name](data)
                 data.neighbor_list = original_neighbor_list


### PR DESCRIPTION
# PR Checklist

- [] Bug fix
- [x] Feature addition/change
- [x] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

**Problem**
When a SumOut sub-model (e.g. SchNet) is wrapped with torch.compile and reused across multiple topologies/mutants — each carrying its own data.neighbor_list — the compiled graph gets guarded on data.neighbor_list even though that sub-model doesn't actually consume the shared dict (SchNet, for instance, builds its own coordinate-dependent neighbor list internally). Because the dict's contents/keys change between mutants, torch.compile treats this as a graph-invalidating input and recompiles on (almost) every call, even though the recompiled graph is functionally identical each time. This defeats the purpose of compiling in workflows that cycle through many mutants/topologies in a single process.

**Fix**
Add an optional own_nl_models argument to SumOut.__init__. For any model key listed there, SumOut.forward temporarily clears data.neighbor_list to {} right before calling that model and restores the original dict immediately after. This gives the compiled sub-model a stable, unchanging input for that field across calls — regardless of how many different topologies/mutants are processed — so it only needs to compile once instead of recompiling per mutant.


full_model = SumOut(
    models,
    targets=[ENERGY_KEY, FORCE_KEY],
    own_nl_models=["SchNet"],
)

**Compatibility**
own_nl_models defaults to None, in which case forward is functionally identical to before — data.neighbor_list is passed through unchanged to every sub-model. Existing SumOut users, compiled or not, see no behavior change.