### PR TITLE
Feat/sumout filtered nl

### DIFF
--- a/src/mlcg/nn/gradients.py
+++ b/src/mlcg/nn/gradients.py
@@ -71,9 +71,7 @@ class SumOut(torch.nn.Module):
             targets = [ENERGY_KEY, FORCE_KEY]
         self.targets = targets
         self.models = models
-        self.own_nl_models = (
-            frozenset(own_nl_models) if own_nl_models else frozenset()
-        )
+        self.own_nl_models = set(own_nl_models) if own_nl_models else set()
 
     def forward(self, data: AtomicData) -> AtomicData:
         r"""Sums output properties from individual models into global
@@ -130,7 +128,7 @@ class SumOut(torch.nn.Module):
         for target in self.targets:
             data.out[target] = 0.00
 
-        own_nl_models = getattr(self, "own_nl_models", frozenset())
+        own_nl_models = getattr(self, "own_nl_models", set())
         original_neighbor_list = data.neighbor_list if own_nl_models else None
 
         for name in self.models.keys():

--- a/src/mlcg/nn/gradients.py
+++ b/src/mlcg/nn/gradients.py
@@ -13,6 +13,16 @@ class SumOut(torch.nn.Module):
         Dictionary of predictors models keyed by their name attribute
     targets:
         List of prediction targets that will be pooled
+    dynamic_nl_models:
+        Optional collection of model keys (matching keys in ``models``) whose
+        neighbor list is coordinate-dependent and must be recomputed on every
+        forward call (e.g. a radius-cutoff graph network), rather than reusing
+        the shared/static neighbor list supplied via ``data.neighbor_list``.
+        For these models, ``data.neighbor_list`` is temporarily cleared before
+        the call and restored immediately afterwards, so other models (e.g.
+        bonded priors relying on a fixed topology) are unaffected. Defaults to
+        ``None``, which preserves the previous behavior (no model is treated
+        specially).
 
     Example
     -------
@@ -40,6 +50,15 @@ class SumOut(torch.nn.Module):
                  }
         full_model = SumOut(models, targets=[ENERGY_KEY, FORCE_KEY])
 
+        # If SchNet should rebuild its own (coordinate-dependent) neighbor
+        # list on every call instead of reusing the static one used by the
+        # bonded priors:
+        full_model = SumOut(
+            models,
+            targets=[ENERGY_KEY, FORCE_KEY],
+            dynamic_nl_models=["SchNet"],
+        )
+
 
     """
 
@@ -49,12 +68,16 @@ class SumOut(torch.nn.Module):
         self,
         models: torch.nn.ModuleDict,
         targets: List[str] = None,
+        dynamic_nl_models: Sequence[str] = None,
     ):
         super(SumOut, self).__init__()
         if targets is None:
             targets = [ENERGY_KEY, FORCE_KEY]
         self.targets = targets
         self.models = models
+        self.dynamic_nl_models = (
+            frozenset(dynamic_nl_models) if dynamic_nl_models else frozenset()
+        )
 
     def forward(self, data: AtomicData) -> AtomicData:
         r"""Sums output properties from individual models into global
@@ -110,8 +133,16 @@ class SumOut(torch.nn.Module):
         """
         for target in self.targets:
             data.out[target] = 0.00
+
+        original_neighbor_list = data.neighbor_list if self.dynamic_nl_models else None
+
         for name in self.models.keys():
-            data = self.models[name](data)
+            if name in self.dynamic_nl_models:
+                data.neighbor_list = {}
+                data = self.models[name](data)
+                data.neighbor_list = original_neighbor_list
+            else:
+                data = self.models[name](data)
             for target in self.targets:
                 data.out[target] += data.out[name][target]
         return data

--- a/src/mlcg/nn/gradients.py
+++ b/src/mlcg/nn/gradients.py
@@ -130,12 +130,11 @@ class SumOut(torch.nn.Module):
         for target in self.targets:
             data.out[target] = 0.00
 
-        original_neighbor_list = (
-            data.neighbor_list if self.own_nl_models else None
-        )
+        own_nl_models = getattr(self, "own_nl_models", frozenset())
+        original_neighbor_list = data.neighbor_list if own_nl_models else None
 
         for name in self.models.keys():
-            if name in self.own_nl_models:
+            if name in own_nl_models:
                 data.neighbor_list = {}
                 data = self.models[name](data)
                 data.neighbor_list = original_neighbor_list

--- a/src/mlcg/nn/gradients.py
+++ b/src/mlcg/nn/gradients.py
@@ -71,7 +71,9 @@ class SumOut(torch.nn.Module):
             targets = [ENERGY_KEY, FORCE_KEY]
         self.targets = targets
         self.models = models
-        self.own_nl_models = frozenset(own_nl_models) if own_nl_models else frozenset()
+        self.own_nl_models = (
+            frozenset(own_nl_models) if own_nl_models else frozenset()
+        )
 
     def forward(self, data: AtomicData) -> AtomicData:
         r"""Sums output properties from individual models into global
@@ -128,7 +130,9 @@ class SumOut(torch.nn.Module):
         for target in self.targets:
             data.out[target] = 0.00
 
-        original_neighbor_list = data.neighbor_list if self.own_nl_models else None
+        original_neighbor_list = (
+            data.neighbor_list if self.own_nl_models else None
+        )
 
         for name in self.models.keys():
             if name in self.own_nl_models:

--- a/src/mlcg/nn/gradients.py
+++ b/src/mlcg/nn/gradients.py
@@ -13,16 +13,14 @@ class SumOut(torch.nn.Module):
         Dictionary of predictors models keyed by their name attribute
     targets:
         List of prediction targets that will be pooled
-    dynamic_nl_models:
-        Optional collection of model keys (matching keys in ``models``) whose
-        neighbor list is coordinate-dependent and must be recomputed on every
-        forward call (e.g. a radius-cutoff graph network), rather than reusing
-        the shared/static neighbor list supplied via ``data.neighbor_list``.
-        For these models, ``data.neighbor_list`` is temporarily cleared before
-        the call and restored immediately afterwards, so other models (e.g.
-        bonded priors relying on a fixed topology) are unaffected. Defaults to
-        ``None``, which preserves the previous behavior (no model is treated
-        specially).
+    own_nl_models:
+        Optional model keys that should not receive the shared
+        ``data.neighbor_list``. Useful in cases where a model needs to
+        build its own coordinate-dependent neighbor list and in compilation
+        cases. For each key listed here, ``data.neighbor_list``
+        is temporarily cleared right before that model's call and restored
+        immediately after, leaving the other models unaffected. Defaults to
+        ``None``.
 
     Example
     -------
@@ -50,13 +48,11 @@ class SumOut(torch.nn.Module):
                  }
         full_model = SumOut(models, targets=[ENERGY_KEY, FORCE_KEY])
 
-        # If SchNet should rebuild its own (coordinate-dependent) neighbor
-        # list on every call instead of reusing the static one used by the
-        # bonded priors:
+        # Withhold the shared neighbor_list from SchNet's call:
         full_model = SumOut(
             models,
             targets=[ENERGY_KEY, FORCE_KEY],
-            dynamic_nl_models=["SchNet"],
+            own_nl_models=["SchNet"],
         )
 
 
@@ -68,16 +64,14 @@ class SumOut(torch.nn.Module):
         self,
         models: torch.nn.ModuleDict,
         targets: List[str] = None,
-        dynamic_nl_models: Sequence[str] = None,
+        own_nl_models: Sequence[str] = None,
     ):
         super(SumOut, self).__init__()
         if targets is None:
             targets = [ENERGY_KEY, FORCE_KEY]
         self.targets = targets
         self.models = models
-        self.dynamic_nl_models = (
-            frozenset(dynamic_nl_models) if dynamic_nl_models else frozenset()
-        )
+        self.own_nl_models = frozenset(own_nl_models) if own_nl_models else frozenset()
 
     def forward(self, data: AtomicData) -> AtomicData:
         r"""Sums output properties from individual models into global
@@ -134,10 +128,10 @@ class SumOut(torch.nn.Module):
         for target in self.targets:
             data.out[target] = 0.00
 
-        original_neighbor_list = data.neighbor_list if self.dynamic_nl_models else None
+        original_neighbor_list = data.neighbor_list if self.own_nl_models else None
 
         for name in self.models.keys():
-            if name in self.dynamic_nl_models:
+            if name in self.own_nl_models:
                 data.neighbor_list = {}
                 data = self.models[name](data)
                 data.neighbor_list = original_neighbor_list

--- a/tests/unit/nn/test_outs.py
+++ b/tests/unit/nn/test_outs.py
@@ -64,7 +64,7 @@ try:
         "atomic_numbers": unique_test_types,
     }
     mace_model = StandardMACE(**mace_config)
-    mace_force_model = GradientsOut(mace_model, targets=[FORCE_KEY]).float()
+    mace_force_model = GradientsOut(mace_model, targets=[FORCE_KEY])#.float()
 except Exception as e:
     print(e)
     mace_force_model = DummyGradientModel("mace")
@@ -85,7 +85,7 @@ schnet = StandardSchNet(
     num_interactions=1,
     max_num_neighbors=1000,
 )
-schnet_force_model = GradientsOut(schnet, targets=[FORCE_KEY]).double()
+schnet_force_model = GradientsOut(schnet, targets=[FORCE_KEY])#.double()
 
 
 @pytest.mark.parametrize(
@@ -124,6 +124,10 @@ def test_outs(ASE_prior_model, out_targets):
         assert shape == collated_data.out[target].shape
 
 
+DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+
+
+@pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize(
     "ASE_prior_model, network_model, out_targets",
     [
@@ -132,15 +136,20 @@ def test_outs(ASE_prior_model, out_targets):
     ],
     indirect=["ASE_prior_model"],
 )
-def test_sum_outs(ASE_prior_model, network_model, out_targets):
+def test_sum_outs(ASE_prior_model, network_model, out_targets, device):
     """Tests property aggregating with SumOut"""
     if network_model.name == "mace" and HAS_MACE == False:
         pytest.skip("Skipping test, MACE installation not found...")
-    data_dictionary = ASE_prior_model(sum_out=False)
+
+    torch._functorch.config.donated_buffer = False
+
+    data_dictionary = ASE_prior_model(sum_out=False, device=device)
 
     prior_model = data_dictionary["model"]
-    collated_data = data_dictionary["collated_prior_data"]
-    collated_data_2 = deepcopy(data_dictionary["collated_prior_data"])
+    network_model = network_model.to(device)
+    collated_data = data_dictionary["collated_prior_data"].to(device)
+    collated_data_2 = deepcopy(collated_data)
+    collated_data_3 = deepcopy(collated_data)
 
     for prior in prior_model.keys():
         collated_data = prior_model[prior](collated_data)
@@ -160,14 +169,27 @@ def test_sum_outs(ASE_prior_model, network_model, out_targets):
 
     # Test to make sure the the aggregate data matches the target totals
     for target in out_targets:
-        np.testing.assert_allclose(
-            target_totals[target].detach().numpy(),
-            collated_data_2.out[target].detach().numpy(),
+        torch.testing.assert_close(
+            target_totals[target].detach(),
+            collated_data_2.out[target].detach(),
             atol=1e-5,
+            rtol=1e-5,
         )
 
+    # Compiled: the same equivalence should hold once the aggregate model
+    # is compiled. A looser tolerance is used here since torch.compile's
+    # Inductor backend fuses and reorders reductions, so it will not match
+    # eager execution bit-for-bit.
+    compiled_model = torch.compile(aggregate_model, dynamic=True)
+    collated_data_3 = compiled_model(collated_data_3)
 
-DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+    for target in out_targets:
+        torch.testing.assert_close(
+            target_totals[target].detach(),
+            collated_data_3.out[target].detach(),
+            atol=1e-4,
+            rtol=5e-4,
+        )
 
 
 @pytest.mark.parametrize("device", DEVICES)
@@ -221,10 +243,11 @@ def test_sum_outs_own_nl_models(
     eager_data = eager_model(deepcopy(collated_data))
 
     for target in out_targets:
-        np.testing.assert_allclose(
-            reference_data.out[target].detach().cpu().numpy(),
-            eager_data.out[target].detach().cpu().numpy(),
+        torch.testing.assert_close(
+            reference_data.out[target].detach(),
+            eager_data.out[target].detach(),
             atol=1e-5,
+            rtol=1e-5,
         )
 
     # Compiled: the same equivalence should hold once the aggregate model
@@ -243,9 +266,9 @@ def test_sum_outs_own_nl_models(
     compiled_data = compiled_model(deepcopy(collated_data))
 
     for target in out_targets:
-        np.testing.assert_allclose(
-            reference_data.out[target].detach().cpu().numpy(),
-            compiled_data.out[target].detach().cpu().numpy(),
-            atol=1e-3,
-            rtol=1e-3,
+        torch.testing.assert_close(
+            reference_data.out[target].detach(),
+            compiled_data.out[target].detach(),
+            atol=1e-4,
+            rtol=5e-4,
         )

--- a/tests/unit/nn/test_outs.py
+++ b/tests/unit/nn/test_outs.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from typing import Dict, Union, List
 import torch
+import torch._functorch.config
 import pytest
 import numpy as np
 from torch_geometric.data.collate import collate
@@ -163,4 +164,88 @@ def test_sum_outs(ASE_prior_model, network_model, out_targets):
             target_totals[target].detach().numpy(),
             collated_data_2.out[target].detach().numpy(),
             atol=1e-5,
+        )
+
+
+DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+
+
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize(
+    "ASE_prior_model, network_model, out_targets",
+    [
+        (ASE_prior_model, schnet_force_model, [ENERGY_KEY, FORCE_KEY]),
+        (ASE_prior_model, mace_force_model, [ENERGY_KEY, FORCE_KEY]),
+    ],
+    indirect=["ASE_prior_model"],
+)
+def test_sum_outs_own_nl_models(
+    ASE_prior_model, network_model, out_targets, device
+):
+    """Tests that withholding the shared ``data.neighbor_list`` from a
+    network model via ``SumOut(..., own_nl_models=[...])`` leaves the
+    aggregated predictions unchanged, since the withheld model builds its
+    own coordinate-dependent neighbor list on the fly. This is checked
+    against a reference model that shares the neighbor list with every
+    model, both in eager mode and after compiling the aggregate model with
+    ``torch.compile``, on CPU and, when available, on GPU.
+    """
+    if network_model.name == "mace" and HAS_MACE == False:
+        pytest.skip("Skipping test, MACE installation not found...")
+
+    torch._functorch.config.donated_buffer = False
+
+    data_dictionary = ASE_prior_model(sum_out=False, device=device)
+    prior_model = data_dictionary["model"]
+    collated_data = data_dictionary["collated_prior_data"].to(device)
+
+    def build_module_collection():
+        module_collection = torch.nn.ModuleDict()
+        for key in prior_model.keys():
+            module_collection[key] = deepcopy(prior_model[key])
+        module_collection[network_model.name] = deepcopy(network_model).to(
+            device
+        )
+        return module_collection
+
+    reference_model = SumOut(build_module_collection(), out_targets)
+    reference_data = reference_model(deepcopy(collated_data))
+
+    # Eager: withholding the shared neighbor list from the network model
+    # should not change the aggregated predictions.
+    eager_model = SumOut(
+        build_module_collection(),
+        out_targets,
+        own_nl_models=[network_model.name],
+    )
+    eager_data = eager_model(deepcopy(collated_data))
+
+    for target in out_targets:
+        np.testing.assert_allclose(
+            reference_data.out[target].detach().cpu().numpy(),
+            eager_data.out[target].detach().cpu().numpy(),
+            atol=1e-5,
+        )
+
+    # Compiled: the same equivalence should hold once the aggregate model
+    # (including the own_nl_models bookkeeping) is compiled. A looser
+    # tolerance is used here since torch.compile's Inductor backend fuses
+    # and reorders reductions and does not preserve float64 precision in
+    # all kernels, so it will not match eager execution bit-for-bit.
+    compiled_model = torch.compile(
+        SumOut(
+            build_module_collection(),
+            out_targets,
+            own_nl_models=[network_model.name],
+        ),
+        dynamic=True,
+    )
+    compiled_data = compiled_model(deepcopy(collated_data))
+
+    for target in out_targets:
+        np.testing.assert_allclose(
+            reference_data.out[target].detach().cpu().numpy(),
+            compiled_data.out[target].detach().cpu().numpy(),
+            atol=1e-3,
+            rtol=1e-3,
         )

--- a/tests/unit/nn/test_outs.py
+++ b/tests/unit/nn/test_outs.py
@@ -64,7 +64,7 @@ try:
         "atomic_numbers": unique_test_types,
     }
     mace_model = StandardMACE(**mace_config)
-    mace_force_model = GradientsOut(mace_model, targets=[FORCE_KEY])#.float()
+    mace_force_model = GradientsOut(mace_model, targets=[FORCE_KEY])  # .float()
 except Exception as e:
     print(e)
     mace_force_model = DummyGradientModel("mace")
@@ -85,7 +85,7 @@ schnet = StandardSchNet(
     num_interactions=1,
     max_num_neighbors=1000,
 )
-schnet_force_model = GradientsOut(schnet, targets=[FORCE_KEY])#.double()
+schnet_force_model = GradientsOut(schnet, targets=[FORCE_KEY])  # .double()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# PR Checklist

- [] Bug fix
- [x] Feature addition/change
- [x] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

**Problem**
When a SumOut sub-model (e.g. SchNet) is wrapped with torch.compile and reused across multiple topologies/mutants — each carrying its own data.neighbor_list — the compiled graph gets guarded on data.neighbor_list even though that sub-model doesn't actually consume the shared dict (SchNet, for instance, builds its own coordinate-dependent neighbor list internally). Because the dict's contents/keys change between mutants, torch.compile treats this as a graph-invalidating input and recompiles on (almost) every call, even though the recompiled graph is functionally identical each time. This defeats the purpose of compiling in workflows that cycle through many mutants/topologies in a single process.

**Fix**
Add an optional own_nl_models argument to SumOut.__init__. For any model key listed there, SumOut.forward temporarily clears data.neighbor_list to {} right before calling that model and restores the original dict immediately after. This gives the compiled sub-model a stable, unchanging input for that field across calls — regardless of how many different topologies/mutants are processed — so it only needs to compile once instead of recompiling per mutant.


full_model = SumOut(
    models,
    targets=[ENERGY_KEY, FORCE_KEY],
    own_nl_models=["SchNet"],
)

**Compatibility**
own_nl_models defaults to None, in which case forward is functionally identical to before — data.neighbor_list is passed through unchanged to every sub-model. Existing SumOut users, compiled or not, see no behavior change.