### PR TITLE
Bugfix/nvalchemi pbc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # people autorhized to approve a pull request
-* @sayeg84 @kbno @aguljas @jacopoventurin @yaoyic
+* @sayeg84 @kbno @aguljas @jacopoventurin

--- a/src/mlcg/neighbor_list/nvalchemi_impl.py
+++ b/src/mlcg/neighbor_list/nvalchemi_impl.py
@@ -98,7 +98,11 @@ def nvalchemi_naive_neighbor_list(
 
     if with_pbc:
         (idx_i, idx_j), _, idx_S = result
-        cell_shifts = torch.matmul(idx_S.to(cell.dtype), cell)
+        # cell_shifts = torch.einsum("ni,nij->nj", idx_S.to(cell.dtype), cell[data.batch[idx_i]])
+        cell_shifts = (
+            idx_S.to(cell.dtype).to(cell.dtype).unsqueeze(-1)
+            * cell[data.batch[idx_i]]
+        ).sum(dim=1)
         return idx_i, idx_j, cell_shifts, None
     else:
         (idx_i, idx_j), _ = result
@@ -158,7 +162,7 @@ def nvalchemi_cell_neighbor_list(
     else:
         box_size = 70
         warnings.warn(no_pbc_warning(box_size), UserWarning)
-        # this is required as the method needs
+        # this is required as the method needs PBC
         cell = (
             torch.zeros(
                 data.batch[-1] + 1,
@@ -190,9 +194,12 @@ def nvalchemi_cell_neighbor_list(
     )
 
     (idx_i, idx_j), _, idx_S = result
-
     if with_pbc:
-        cell_shifts = torch.matmul(idx_S.to(cell.dtype), cell)
+        # cell_shifts = torch.einsum("ni,nij->nj", idx_S.to(cell.dtype), cell[data.batch[idx_i]])
+        cell_shifts = (
+            idx_S.to(cell.dtype).to(cell.dtype).unsqueeze(-1)
+            * cell[data.batch[idx_i]]
+        ).sum(dim=1)
     else:
         cell_shifts = torch.zeros(
             (idx_i.shape[0], 3), dtype=data.pos.dtype, device=data.pos.device

--- a/src/mlcg/neighbor_list/nvalchemi_impl.py
+++ b/src/mlcg/neighbor_list/nvalchemi_impl.py
@@ -100,7 +100,7 @@ def nvalchemi_naive_neighbor_list(
         (idx_i, idx_j), _, idx_S = result
         # cell_shifts = torch.einsum("ni,nij->nj", idx_S.to(cell.dtype), cell[data.batch[idx_i]])
         cell_shifts = (
-            idx_S.to(cell.dtype).to(cell.dtype).unsqueeze(-1)
+            idx_S.to(cell.dtype).unsqueeze(-1)
             * cell[data.batch[idx_i]]
         ).sum(dim=1)
         return idx_i, idx_j, cell_shifts, None
@@ -197,7 +197,7 @@ def nvalchemi_cell_neighbor_list(
     if with_pbc:
         # cell_shifts = torch.einsum("ni,nij->nj", idx_S.to(cell.dtype), cell[data.batch[idx_i]])
         cell_shifts = (
-            idx_S.to(cell.dtype).to(cell.dtype).unsqueeze(-1)
+            idx_S.to(cell.dtype).unsqueeze(-1)
             * cell[data.batch[idx_i]]
         ).sum(dim=1)
     else:

--- a/src/mlcg/neighbor_list/nvalchemi_impl.py
+++ b/src/mlcg/neighbor_list/nvalchemi_impl.py
@@ -100,8 +100,7 @@ def nvalchemi_naive_neighbor_list(
         (idx_i, idx_j), _, idx_S = result
         # cell_shifts = torch.einsum("ni,nij->nj", idx_S.to(cell.dtype), cell[data.batch[idx_i]])
         cell_shifts = (
-            idx_S.to(cell.dtype).unsqueeze(-1)
-            * cell[data.batch[idx_i]]
+            idx_S.to(cell.dtype).unsqueeze(-1) * cell[data.batch[idx_i]]
         ).sum(dim=1)
         return idx_i, idx_j, cell_shifts, None
     else:
@@ -197,8 +196,7 @@ def nvalchemi_cell_neighbor_list(
     if with_pbc:
         # cell_shifts = torch.einsum("ni,nij->nj", idx_S.to(cell.dtype), cell[data.batch[idx_i]])
         cell_shifts = (
-            idx_S.to(cell.dtype).unsqueeze(-1)
-            * cell[data.batch[idx_i]]
+            idx_S.to(cell.dtype).unsqueeze(-1) * cell[data.batch[idx_i]]
         ).sum(dim=1)
     else:
         cell_shifts = torch.zeros(

--- a/src/mlcg/neighbor_list/nvalchemi_impl.py
+++ b/src/mlcg/neighbor_list/nvalchemi_impl.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Optional
 import torch
 from torch_geometric.data import Data
-from nvalchemiops.neighborlist import (
+from nvalchemiops.torch.neighbors import (
     batch_cell_list,
     batch_naive_neighbor_list,
 )

--- a/src/mlcg/neighbor_list/nvalchemi_impl.py
+++ b/src/mlcg/neighbor_list/nvalchemi_impl.py
@@ -72,7 +72,7 @@ def nvalchemi_naive_neighbor_list(
     if "pbc" in data:
         pbc = data.pbc
         # the type casting has to be done otherwise the library complains
-        cell = data.cell.to(torch.float64).reshape(-1, 3, 3)
+        cell = data.cell.reshape(-1, 3, 3)
         with_pbc = True
     else:
         pbc = None
@@ -155,7 +155,7 @@ def nvalchemi_cell_neighbor_list(
     if "pbc" in data:
         pbc = data.pbc
         # the type casting has to be done otherwise the library complains
-        cell = data.cell.to(torch.float64).reshape(-1, 3, 3)
+        cell = data.cell.reshape(-1, 3, 3)
         with_pbc = True
 
     else:

--- a/src/mlcg/neighbor_list/nvalchemi_impl.py
+++ b/src/mlcg/neighbor_list/nvalchemi_impl.py
@@ -72,7 +72,7 @@ def nvalchemi_naive_neighbor_list(
     if "pbc" in data:
         pbc = data.pbc
         # the type casting has to be done otherwise the library complains
-        cell = data.cell.to(torch.float32)
+        cell = data.cell.to(torch.float64).reshape(-1, 3, 3)
         with_pbc = True
     else:
         pbc = None
@@ -156,7 +156,7 @@ def nvalchemi_cell_neighbor_list(
     if "pbc" in data:
         pbc = data.pbc
         # the type casting has to be done otherwise the library complains
-        cell = data.cell.to(torch.float32)
+        cell = data.cell.to(torch.float64).reshape(-1, 3, 3)
         with_pbc = True
 
     else:
@@ -252,7 +252,7 @@ def nvalchemi_cell_neighbor_list_raw(
     if "pbc" in data:
         pbc = data.pbc
         # the type casting has to be done otherwise the library complains
-        cell = data.cell.to(torch.float32)
+        cell = data.cell.to(torch.float64).reshape(-1, 3, 3)
         with_pbc = True
 
     else:

--- a/tests/unit/neighbor_list/test_neighbor_list.py
+++ b/tests/unit/neighbor_list/test_neighbor_list.py
@@ -21,6 +21,14 @@ except ImportError:
     )
     NVALCH_AVAILABLE = False
 
+def sort_edges(edge_index, *tensors):
+    if edge_index.numel() == 0:
+        return (edge_index,) + tuple(t for t in tensors)
+    stride = edge_index.max().item() + 1
+    key = edge_index[0] * stride + edge_index[1]
+    order = torch.argsort(key)
+    return (edge_index[:, order],) + tuple(t[order] for t in tensors)
+
 
 def bulk_metal():
     a = 4.0
@@ -87,10 +95,10 @@ def test_neighborlist(nls_method, name, frame, cutoff, self_interaction):
             dd = (data.pos[idx_j] - data.pos[idx_i] + cell_shifts).norm(dim=1)
             dds.extend(dd.numpy())
         dds = np.sort(dds)
+        edge_index = torch.stack([idx_i, idx_j], dim=0)
+        edge_index = sort_edges(edge_index)
         distance_results[met_name] = dds
-        neighs_results[met_name] = torch.stack([idx_i, idx_j], dim=0).sort(
-            dim=1
-        )
+        neighs_results[met_name] = edge_index
     assert np.allclose(
         distance_results["current_nls_method"], distance_results["ase_ref"]
     )

--- a/tests/unit/neighbor_list/test_neighbor_list_nvalchemi.py
+++ b/tests/unit/neighbor_list/test_neighbor_list_nvalchemi.py
@@ -1,0 +1,276 @@
+import pytest
+import ase
+from ase.build import bulk, molecule
+from torch_geometric.loader import DataLoader
+import numpy as np
+import torch
+
+from mlcg.neighbor_list.utils import ase2data
+from mlcg.neighbor_list.ase_impl import ase_neighbor_list
+from mlcg.geometry.internal_coordinates import compute_distances
+
+try:
+    from mlcg.neighbor_list.nvalchemi_impl import (
+        nvalchemi_naive_neighbor_list,
+        nvalchemi_cell_neighbor_list,
+    )
+
+    NVALCH_AVAILABLE = True
+except ImportError:
+    print(
+        "nalchemi is not installed. Please install with "
+        + "pip install nvalchemi-toolkit-ops"
+    )
+    NVALCH_AVAILABLE = False
+
+
+def sort_edges(edge_index, *tensors):
+    if edge_index.numel() == 0:
+        return (edge_index,) + tuple(t for t in tensors)
+    stride = edge_index.max().item() + 1
+    key = edge_index[0] * stride + edge_index[1]
+    order = torch.argsort(key)
+    return (edge_index[:, order],) + tuple(t[order] for t in tensors)
+
+
+def bulk_metal():
+    a = 4.0
+    b = a / 2
+    frames = [
+        ase.Atoms(
+            "Ag",
+            cell=[(0, b, b), (b, 0, b), (b, b, 0)],
+            pbc=True,
+        ),
+        bulk("Cu", "fcc", a=3.6),
+    ]
+    return frames
+
+
+def atomic_structures():
+    frames = [
+        molecule("CH3CH2NH2"),
+        molecule("H2O"),
+        molecule("methylenecyclopropane"),
+    ] + bulk_metal()
+    for frame in frames:
+        yield (frame.get_chemical_symbols(), frame)
+
+
+nvalchemi_test_set = [
+    (name, frame, rc, self_interaction)
+    for (name, frame) in atomic_structures()
+    for rc in range(2, 7, 2)
+    for self_interaction in [False]
+]
+
+# resolved lazily by name so that collection works without nvalchemi installed
+NVALCHEMI_CELL_METHODS = (
+    {
+        "cell": nvalchemi_cell_neighbor_list,
+    }
+    if NVALCH_AVAILABLE
+    else {}
+)
+
+nvalchemi_cell_method_names = ["cell"]
+
+
+@pytest.mark.skipif(
+    not NVALCH_AVAILABLE,
+    reason="nvalchemi is not available (install nvalchemi-toolkit-ops)",
+)
+@pytest.mark.parametrize(
+    "name, frame, cutoff, self_interaction",
+    nvalchemi_test_set,
+)
+def test_neighborlist_nvalchemi(name, frame, cutoff, self_interaction):
+    """Check that nvalchemi_neighbor_list gives the same NL as ASE by comparing
+    the resulting sorted list of distances between neighbors."""
+    data_list = [ase2data(frame)]
+    dataloader = DataLoader(data_list, batch_size=1)
+    distance_results = {}
+    neighs_results = {}
+    method_list = ["current_nls_method", "ase_ref"]
+    for met_name in method_list:
+        dds = []
+        for data in dataloader:
+            if met_name == "ase_ref":
+                met = ase_neighbor_list
+            else:
+                met = nvalchemi_naive_neighbor_list
+            idx_i, idx_j, cell_shifts, _ = met(
+                data, cutoff, self_interaction=self_interaction
+            )
+            dd = (data.pos[idx_j] - data.pos[idx_i] + cell_shifts).norm(dim=1)
+            dds.extend(dd.numpy())
+        dds = np.sort(dds)
+        edge_index = torch.stack([idx_i, idx_j], dim=0)
+        edge_index = sort_edges(edge_index)
+        distance_results[met_name] = dds
+        neighs_results[met_name] = edge_index
+    assert np.allclose(
+        distance_results["current_nls_method"], distance_results["ase_ref"]
+    )
+    assert np.allclose(
+        neighs_results["current_nls_method"], neighs_results["ase_ref"]
+    )
+
+
+@pytest.mark.skipif(
+    not NVALCH_AVAILABLE,
+    reason="nvalchemi is not available (install nvalchemi-toolkit-ops)",
+)
+@pytest.mark.parametrize("nls_name", nvalchemi_cell_method_names)
+def test_neighborlist_pbc_nvalchemi(nls_name):
+    """Test that neighbor list with PBC correctly handles periodic images
+    and produces the same results as ASE reference implementation."""
+    nls_method = NVALCHEMI_CELL_METHODS[nls_name]
+
+    # Create test structures with PBC
+    structures = [
+        bulk("Cu", "fcc", a=3.6),
+    ]
+
+    cutoffs = [
+        3.0,
+    ]
+
+    for structure in structures:
+        for cutoff in cutoffs:
+            for self_interaction in [False]:
+                # Convert to data format
+                data_list = [ase2data(structure)]
+                dataloader = DataLoader(data_list, batch_size=1)
+
+                # Get nvalchemi neighbor list distances
+                nvalchemi_distances = []
+                for data in dataloader:
+                    if "cell" in data:
+                        print("Cell:\n", data.cell)
+                    idx_i, idx_j, cell_shifts, _ = nls_method(
+                        data, cutoff, self_interaction=self_interaction
+                    )
+                    mapping = torch.stack([idx_i, idx_j], dim=0)
+                    dd = compute_distances(data.pos, mapping, cell_shifts)
+                    nvalchemi_distances.extend(dd.numpy())
+
+                nvalchemi_distances = np.sort(nvalchemi_distances)
+
+                # Get ASE reference distances
+                ase_distances = []
+                for data in dataloader:
+                    idx_i, idx_j, ase_cell_shifts, _ = ase_neighbor_list(
+                        data, cutoff, self_interaction=self_interaction
+                    )
+                    dd = (
+                        data.pos[idx_j] - data.pos[idx_i] + ase_cell_shifts
+                    ).norm(dim=1)
+                    ase_distances.extend(dd.numpy())
+
+                ase_distances = np.sort(ase_distances)
+
+                assert np.allclose(
+                    ase_distances, nvalchemi_distances, rtol=1e-5, atol=1e-6
+                )
+
+                assert np.all(nvalchemi_distances <= cutoff + 1e-6)
+
+
+@pytest.mark.skipif(
+    not NVALCH_AVAILABLE,
+    reason="nvalchemi is not available (install nvalchemi-toolkit-ops)",
+)
+@pytest.mark.parametrize("nls_name", nvalchemi_cell_method_names)
+def test_pbc_minimum_image_convention_nvalchemi(nls_name):
+    """Test that PBC neighbor list correctly applies minimum image convention.
+    Neighbors should be found across periodic boundaries at the shortest distance.
+    """
+    nls_method = NVALCHEMI_CELL_METHODS[nls_name]
+
+    # Create a simple cubic cell with one atom
+    atoms = ase.Atoms(
+        "Ar",
+        positions=[[0.1, 0.1, 0.1]],
+        cell=[10.0, 10.0, 10.0],
+        pbc=True,
+    )
+
+    cutoff = 3.0
+    data_list = [ase2data(atoms)]
+    dataloader = DataLoader(data_list, batch_size=1)
+
+    for data in dataloader:
+        idx_i, idx_j, cell_shifts, _ = nls_method(
+            data, cutoff, self_interaction=False
+        )
+
+        assert len(idx_i) == 0, "Single isolated atom should have no neighbors"
+
+    atoms = ase.Atoms(
+        "Ar2",
+        positions=[[0.1, 0.1, 0.1], [9.9, 0.1, 0.1]],
+        cell=[10.0, 10.0, 10.0],
+        pbc=True,
+    )
+
+    data_list = [ase2data(atoms)]
+    dataloader = DataLoader(data_list, batch_size=1)
+
+    distances = []
+    for data in dataloader:
+        idx_i, idx_j, cell_shifts, _ = nls_method(
+            data, cutoff, self_interaction=False
+        )
+
+        mapping = torch.stack([idx_i, idx_j], dim=0)
+        dd = compute_distances(data.pos, mapping, cell_shifts)
+        distances.extend(dd.numpy())
+
+        distances = np.sort(distances)
+        assert np.all(distances < 1.0), (
+            f"Minimum image convention not applied correctly. "
+            f"Distances: {distances}"
+        )
+
+
+@pytest.mark.skipif(
+    not NVALCH_AVAILABLE,
+    reason="nvalchemi is not available (install nvalchemi-toolkit-ops)",
+)
+@pytest.mark.parametrize("nls_name", nvalchemi_cell_method_names)
+def test_mixed_pbc_nvalchemi(nls_name):
+    """Test neighbor list with partial periodic boundary conditions."""
+    nls_method = NVALCHEMI_CELL_METHODS[nls_name]
+
+    atoms = ase.Atoms(
+        "C4",
+        positions=[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 5.0],
+        ],
+        cell=[5.0, 5.0, 10.0],
+        pbc=[True, True, False],  # Periodic in x,y but not z
+    )
+
+    cutoff = 2.0
+    data_list = [ase2data(atoms)]
+    dataloader = DataLoader(data_list, batch_size=1)
+    distances = []
+    for data in dataloader:
+        idx_i, idx_j, cell_shifts, _ = nls_method(
+            data, cutoff, self_interaction=False
+        )
+
+        mapping = torch.stack([idx_i, idx_j], dim=0)
+        dd = compute_distances(data.pos, mapping, cell_shifts)
+        distances.extend(dd.numpy())
+        distances = np.sort(distances)
+
+        assert np.all(distances <= cutoff + 1e-6)
+
+        atoms_involved = torch.cat([idx_i, idx_j]).unique()
+
+        assert len(atoms_involved) >= 3

--- a/tests/unit/neighbor_list/test_neighbor_list_nvalchemi.py
+++ b/tests/unit/neighbor_list/test_neighbor_list_nvalchemi.py
@@ -97,6 +97,7 @@ def test_neighborlist_nvalchemi(name, frame, cutoff, self_interaction):
     for met_name in method_list:
         dds = []
         for data in dataloader:
+            data.cell = data.cell.to(data.pos.dtype)
             if met_name == "ase_ref":
                 met = ase_neighbor_list
             else:
@@ -149,6 +150,7 @@ def test_neighborlist_pbc_nvalchemi(nls_name):
                 # Get nvalchemi neighbor list distances
                 nvalchemi_distances = []
                 for data in dataloader:
+                    data.cell = data.cell.to(data.pos.dtype)
                     if "cell" in data:
                         print("Cell:\n", data.cell)
                     idx_i, idx_j, cell_shifts, _ = nls_method(
@@ -171,6 +173,7 @@ def test_neighborlist_pbc_nvalchemi(nls_name):
                 # Get ASE reference distances
                 ase_distances = []
                 for data in dataloader:
+                    data.cell = data.cell.to(data.pos.dtype)
                     idx_i, idx_j, ase_cell_shifts, _ = ase_neighbor_list(
                         data, cutoff, self_interaction=self_interaction
                     )
@@ -212,6 +215,7 @@ def test_pbc_minimum_image_convention_nvalchemi(nls_name):
     dataloader = DataLoader(data_list, batch_size=1)
 
     for data in dataloader:
+        data.cell = data.cell.to(data.pos.dtype)
         idx_i, idx_j, cell_shifts, _ = nls_method(
             data, cutoff, self_interaction=False
         )
@@ -230,13 +234,14 @@ def test_pbc_minimum_image_convention_nvalchemi(nls_name):
 
     distances = []
     for data in dataloader:
+        data.cell = data.cell.to(data.pos.dtype)
         idx_i, idx_j, cell_shifts, _ = nls_method(
             data, cutoff, self_interaction=False
         )
         if nls_name == "raw":
             cell = data.cell.reshape(-1, 3, 3)
             cell_shifts = (
-                cell_shifts.to(cell.dtype).to(cell.dtype).unsqueeze(-1)
+                cell_shifts.to(cell.dtype).unsqueeze(-1)
                 * cell[data.batch[idx_i]]
             ).sum(dim=1)
 
@@ -277,6 +282,7 @@ def test_mixed_pbc_nvalchemi(nls_name):
     dataloader = DataLoader(data_list, batch_size=1)
     distances = []
     for data in dataloader:
+        data.cell = data.cell.to(data.pos.dtype)
         idx_i, idx_j, cell_shifts, _ = nls_method(
             data, cutoff, self_interaction=False
         )

--- a/tests/unit/neighbor_list/test_neighbor_list_nvalchemi.py
+++ b/tests/unit/neighbor_list/test_neighbor_list_nvalchemi.py
@@ -13,6 +13,7 @@ try:
     from mlcg.neighbor_list.nvalchemi_impl import (
         nvalchemi_naive_neighbor_list,
         nvalchemi_cell_neighbor_list,
+        nvalchemi_cell_neighbor_list_raw,
     )
 
     NVALCH_AVAILABLE = True
@@ -68,12 +69,13 @@ nvalchemi_test_set = [
 NVALCHEMI_CELL_METHODS = (
     {
         "cell": nvalchemi_cell_neighbor_list,
+        "raw": nvalchemi_cell_neighbor_list_raw,
     }
     if NVALCH_AVAILABLE
     else {}
 )
 
-nvalchemi_cell_method_names = ["cell"]
+nvalchemi_cell_method_names = ["cell","raw"]
 
 
 @pytest.mark.skipif(
@@ -102,6 +104,7 @@ def test_neighborlist_nvalchemi(name, frame, cutoff, self_interaction):
             idx_i, idx_j, cell_shifts, _ = met(
                 data, cutoff, self_interaction=self_interaction
             )
+            
             dd = (data.pos[idx_j] - data.pos[idx_i] + cell_shifts).norm(dim=1)
             dds.extend(dd.numpy())
         dds = np.sort(dds)
@@ -151,6 +154,12 @@ def test_neighborlist_pbc_nvalchemi(nls_name):
                     idx_i, idx_j, cell_shifts, _ = nls_method(
                         data, cutoff, self_interaction=self_interaction
                     )
+                    if nls_name == "raw":
+                        cell = data.cell.reshape(-1,3,3)
+                        cell_shifts = (
+                            cell_shifts.to(cell.dtype).to(cell.dtype).unsqueeze(-1)
+                            * cell[data.batch[idx_i]]
+                        ).sum(dim=1)
                     mapping = torch.stack([idx_i, idx_j], dim=0)
                     dd = compute_distances(data.pos, mapping, cell_shifts)
                     nvalchemi_distances.extend(dd.numpy())
@@ -222,6 +231,12 @@ def test_pbc_minimum_image_convention_nvalchemi(nls_name):
         idx_i, idx_j, cell_shifts, _ = nls_method(
             data, cutoff, self_interaction=False
         )
+        if nls_name == "raw":
+            cell = data.cell.reshape(-1,3,3)
+            cell_shifts = (
+                cell_shifts.to(cell.dtype).to(cell.dtype).unsqueeze(-1)
+                * cell[data.batch[idx_i]]
+            ).sum(dim=1)
 
         mapping = torch.stack([idx_i, idx_j], dim=0)
         dd = compute_distances(data.pos, mapping, cell_shifts)
@@ -263,6 +278,14 @@ def test_mixed_pbc_nvalchemi(nls_name):
         idx_i, idx_j, cell_shifts, _ = nls_method(
             data, cutoff, self_interaction=False
         )
+
+        cell = data.cell.reshape(-1,3,3)
+        if nls_name == "raw":
+            cell = data.cell.reshape(-1,3,3)
+            cell_shifts = (
+                cell_shifts.to(cell.dtype).unsqueeze(-1)
+                * cell[data.batch[idx_i]]
+            ).sum(dim=1)
 
         mapping = torch.stack([idx_i, idx_j], dim=0)
         dd = compute_distances(data.pos, mapping, cell_shifts)

--- a/tests/unit/neighbor_list/test_neighbor_list_nvalchemi.py
+++ b/tests/unit/neighbor_list/test_neighbor_list_nvalchemi.py
@@ -75,7 +75,7 @@ NVALCHEMI_CELL_METHODS = (
     else {}
 )
 
-nvalchemi_cell_method_names = ["cell","raw"]
+nvalchemi_cell_method_names = ["cell", "raw"]
 
 
 @pytest.mark.skipif(
@@ -104,7 +104,7 @@ def test_neighborlist_nvalchemi(name, frame, cutoff, self_interaction):
             idx_i, idx_j, cell_shifts, _ = met(
                 data, cutoff, self_interaction=self_interaction
             )
-            
+
             dd = (data.pos[idx_j] - data.pos[idx_i] + cell_shifts).norm(dim=1)
             dds.extend(dd.numpy())
         dds = np.sort(dds)
@@ -155,9 +155,11 @@ def test_neighborlist_pbc_nvalchemi(nls_name):
                         data, cutoff, self_interaction=self_interaction
                     )
                     if nls_name == "raw":
-                        cell = data.cell.reshape(-1,3,3)
+                        cell = data.cell.reshape(-1, 3, 3)
                         cell_shifts = (
-                            cell_shifts.to(cell.dtype).to(cell.dtype).unsqueeze(-1)
+                            cell_shifts.to(cell.dtype)
+                            .to(cell.dtype)
+                            .unsqueeze(-1)
                             * cell[data.batch[idx_i]]
                         ).sum(dim=1)
                     mapping = torch.stack([idx_i, idx_j], dim=0)
@@ -232,7 +234,7 @@ def test_pbc_minimum_image_convention_nvalchemi(nls_name):
             data, cutoff, self_interaction=False
         )
         if nls_name == "raw":
-            cell = data.cell.reshape(-1,3,3)
+            cell = data.cell.reshape(-1, 3, 3)
             cell_shifts = (
                 cell_shifts.to(cell.dtype).to(cell.dtype).unsqueeze(-1)
                 * cell[data.batch[idx_i]]
@@ -279,9 +281,9 @@ def test_mixed_pbc_nvalchemi(nls_name):
             data, cutoff, self_interaction=False
         )
 
-        cell = data.cell.reshape(-1,3,3)
+        cell = data.cell.reshape(-1, 3, 3)
         if nls_name == "raw":
-            cell = data.cell.reshape(-1,3,3)
+            cell = data.cell.reshape(-1, 3, 3)
             cell_shifts = (
                 cell_shifts.to(cell.dtype).unsqueeze(-1)
                 * cell[data.batch[idx_i]]

--- a/tests/unit/neighbor_list/test_neighbor_list_torch.py
+++ b/tests/unit/neighbor_list/test_neighbor_list_torch.py
@@ -10,16 +10,6 @@ from mlcg.neighbor_list.ase_impl import ase_neighbor_list
 from mlcg.neighbor_list.torch_impl import torch_neighbor_list
 from mlcg.geometry.internal_coordinates import compute_distances
 
-try:
-    from mlcg.neighbor_list.nvalchemi_impl import nvalchemi_neighbor_list
-
-    NVALCH_AVAILABLE = True
-except ImportError:
-    print(
-        "nalchemiis not installed. Please install with "
-        + "pip install nvalchemi-toolkit-ops"
-    )
-    NVALCH_AVAILABLE = False
 
 def sort_edges(edge_index, *tensors):
     if edge_index.numel() == 0:
@@ -61,13 +51,12 @@ test_set = [
     for self_interaction in [False, True]
 ]
 
-if NVALCH_AVAILABLE:
-    test_set += [
-        (nvalchemi_neighbor_list, name, frame, rc, self_interaction)
-        for (name, frame) in atomic_structures()
-        for rc in range(2, 7, 2)
-        for self_interaction in [False]
-    ]
+nvalchemi_test_set = [
+    (name, frame, rc, self_interaction)
+    for (name, frame) in atomic_structures()
+    for rc in range(2, 7, 2)
+    for self_interaction in [False]
+]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# PR Checklist

- [x] Bug fix
- [] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

### Describe your changes here:

NVAlchemi changed the location of its libraries from version 0.2.0 to 0.3.1, which is the one we are currently supporting. This change enables the support in 0.3.1, as well as solving a problem related to the incorrect multiplication of cell_shifts by the cell dimension in bacthed cell pbc neighbor computation. 