### PR TITLE
Feat/energy minimizer

### DIFF
--- a/examples/input_yamls/minimize_energy.yaml
+++ b/examples/input_yamls/minimize_energy.yaml
@@ -1,0 +1,9 @@
+minimizer:
+  fmax: 0.05
+  steps: 500
+  device: cpu
+  dtype: torch.float32
+  optimizer_cls: torch.optim.LBFGS
+model_file: SOME_PATH
+structure_file: SOME_PATH
+output_file: minimized_structures.pt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ mlcg-train = "mlcg.scripts.mlcg_train:main"
 mlcg-train_multischeduler = "mlcg.scripts.mlcg_train_multischeduler:main"
 mlcg-nvt_langevin = "mlcg.scripts.mlcg_nvt_langevin:main"
 mlcg-nvt_pt_langevin = "mlcg.scripts.mlcg_nvt_pt_langevin:main"
+mlcg-minimize_energy = "mlcg.scripts.mlcg_minimize_energy:main"
 
 [tool.black]
 line-length = 80

--- a/src/mlcg/scripts/mlcg_minimize_energy.py
+++ b/src/mlcg/scripts/mlcg_minimize_energy.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+
+from time import ctime
+import torch
+
+from mlcg.simulation import parse_minimizer_config, minimize_energy
+
+
+def main():
+    print(f"Starting minimization at {ctime()} with {minimize_energy}")
+    (
+        model,
+        initial_data_list,
+        minimizer_kwargs,
+        output_file,
+    ) = parse_minimizer_config()
+
+    minimized = minimize_energy(model, initial_data_list, **minimizer_kwargs)
+    torch.save(minimized, output_file)
+    print(f"Ending minimization at {ctime()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mlcg/simulation/__init__.py
+++ b/src/mlcg/simulation/__init__.py
@@ -1,6 +1,6 @@
 from .langevin import LangevinSimulation, OverdampedSimulation
 from .parallel_tempering import PTSimulation
 from .base import _Simulation
-from .cli import parse_simulation_config
+from .cli import parse_simulation_config, parse_minimizer_config
 from .specialize_prior import condense_all_priors_for_simulation
 from .minimizer import minimize_energy

--- a/src/mlcg/simulation/__init__.py
+++ b/src/mlcg/simulation/__init__.py
@@ -3,4 +3,4 @@ from .parallel_tempering import PTSimulation
 from .base import _Simulation
 from .cli import parse_simulation_config
 from .specialize_prior import condense_all_priors_for_simulation
-from .minimizer import MLCGCalculator, minimize_energy, minimize_energy_ase
+from .minimizer import minimize_energy

--- a/src/mlcg/simulation/__init__.py
+++ b/src/mlcg/simulation/__init__.py
@@ -3,3 +3,4 @@ from .parallel_tempering import PTSimulation
 from .base import _Simulation
 from .cli import parse_simulation_config
 from .specialize_prior import condense_all_priors_for_simulation
+from .minimizer import MLCGCalculator, minimize_energy, minimize_energy_ase

--- a/src/mlcg/simulation/cli.py
+++ b/src/mlcg/simulation/cli.py
@@ -1,3 +1,4 @@
+import os.path as osp
 from typing import Any, List, Dict, Tuple, Sequence
 import torch
 from jsonargparse import (
@@ -13,6 +14,7 @@ from . import (
     PTSimulation,
     OverdampedSimulation,
 )
+from .minimizer import minimize_energy
 from ..data import AtomicData
 from ..nn import load_and_adapt_old_checkpoint
 from ..utils import dump_yaml
@@ -122,6 +124,112 @@ def parse_simulation_config(
     profile = config.pop("profile")
 
     return model, initial_data_list, betas, simulation, profile
+
+
+def parse_minimizer_config(
+    description: str = "Energy minimization command line tool",
+    parser_kwargs: Dict[str, Any] = None,
+) -> Tuple[torch.nn.Module, List[AtomicData], Dict[str, Any], str]:
+    """Utility to parse a configuration file to run :py:func:`minimize_energy`
+    from the command line, mirroring :py:func:`parse_simulation_config`.
+
+    Parameters
+    ----------
+    description : str, optional
+        cli description, by default "Energy minimization command line tool"
+    parser_kwargs : Dict[str, Any], optional
+        more arguments to the parser, by default None
+
+    Returns
+    -------
+    model, initial_data_list, minimizer_kwargs, output_file
+    """
+    parser_kwargs = {} if parser_kwargs is None else parser_kwargs
+    parser_kwargs.update({"description": description})
+    parser = SimulationParser(**parser_kwargs)
+    # minimize_energy is a plain function rather than a _Simulation subclass,
+    # so its arguments are added directly instead of via add_simulation_args.
+    # model/configurations are skipped here: they are loaded from
+    # model_file/structure_file below instead of being part of the config.
+    parser.add_function_arguments(
+        minimize_energy,
+        "minimizer",
+        skip={"model", "configurations"},
+        fail_untyped=False,
+    )
+
+    parser.add_argument(
+        "-mf",
+        "--model_file",
+        metavar="FN",
+        type=Path_fr,
+        help="path to the pytorch model file (including the priors) in pytorch format",
+    )
+
+    parser.add_argument(
+        "-sf",
+        "--structure_file",
+        metavar="FN",
+        type=Path_fr,
+        help="path to the starting configurations (a list of un-collated "
+        "AtomicData) in pytorch format",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output_file",
+        metavar="FN",
+        type=str,
+        help="path at which the minimized configurations (a list of "
+        "AtomicData) will be saved, in pytorch format",
+    )
+
+    config = parser.parse_args()
+    # save config
+    exported_config = {}
+    for k, v in config.items():
+        # Path_fr must be converted to string otherwise they can't be saved
+        if isinstance(v, Path_fr):
+            exported_config[k] = str(v)
+        # redundant to save the path to the original config
+        elif k == "config":
+            continue
+        elif k == "minimizer":
+            # dtype and optimizer_cls are resolved to actual torch.dtype/type
+            # objects by this point, neither of which ruamel.yaml can
+            # represent, so they are dumped back out as import path strings.
+            exported_config[k] = {
+                mk: (
+                    str(mv)
+                    if isinstance(mv, torch.dtype)
+                    else (
+                        f"{mv.__module__}.{mv.__qualname__}"
+                        if isinstance(mv, type)
+                        else mv
+                    )
+                )
+                for mk, mv in v.items()
+            }
+        else:
+            exported_config[k] = v
+    out_name = osp.splitext(config["output_file"])[0]
+    dump_yaml(f"{out_name}_config.yaml", exported_config)
+
+    model_fn = config.pop("model_file")
+    model = load_and_adapt_old_checkpoint(
+        (model_fn if isinstance(model_fn, str) else model_fn())
+    )
+
+    structures_fn = config.pop("structure_file")
+    initial_data_list = torch.load(
+        (structures_fn if isinstance(structures_fn, str) else structures_fn()),
+        weights_only=False,
+    )
+
+    minimizer_kwargs = config.pop("minimizer")
+    output_file = config.pop("output_file")
+
+    return model, initial_data_list, minimizer_kwargs, output_file
 
 
 class ConfigurationException(Exception):

--- a/src/mlcg/simulation/minimizer.py
+++ b/src/mlcg/simulation/minimizer.py
@@ -295,9 +295,7 @@ def minimize_energy_ase(
 
         idx = None if fixed_atoms is None else fixed_atoms[i]
         if idx is not None and len(idx) > 0:
-            atoms.set_constraint(
-                FixAtoms(indices=np.asarray(idx, dtype=int))
-            )
+            atoms.set_constraint(FixAtoms(indices=np.asarray(idx, dtype=int)))
 
         optimizer = optimizer_cls(atoms, **optimizer_kwargs)
         optimizer.run(fmax=fmax, steps=steps)
@@ -312,7 +310,6 @@ def minimize_energy_ase(
         minimized.append(new_data)
 
     return minimized
-
 
 
 def minimize_energy(
@@ -406,7 +403,7 @@ def minimize_energy(
         out = model(batch)
         if FORCE_KEY not in out.out:
             raise KeyError(
-                f"Model output does not contain \'{FORCE_KEY}\'. The model "
+                f"Model output does not contain '{FORCE_KEY}'. The model "
                 "passed to minimize_energy must be wrapped with "
                 "mlcg.nn.gradients.GradientsOut (or SumOut over "
                 "GradientsOut-wrapped terms) with forces among its targets "

--- a/src/mlcg/simulation/minimizer.py
+++ b/src/mlcg/simulation/minimizer.py
@@ -25,9 +25,9 @@ def _num_structures(data: AtomicData) -> int:
     return 1
 
 
-def _validate_configurations_and_fixed_atoms(
+def _validate_configurations_and_free_atoms(
     configurations: List[AtomicData],
-    fixed_atoms: Optional[List[Optional[Sequence[int]]]],
+    free_atoms: Optional[List[Optional[Sequence[int]]]],
 ) -> None:
     r"""Input validation for :py:func:`minimize_energy`."""
     if len(configurations) == 0:
@@ -44,13 +44,13 @@ def _validate_configurations_and_fixed_atoms(
                 "AtomicData structure per list element."
             )
 
-    if fixed_atoms is not None:
-        if len(fixed_atoms) != len(configurations):
+    if free_atoms is not None:
+        if len(free_atoms) != len(configurations):
             raise ValueError(
-                f"len(fixed_atoms)={len(fixed_atoms)} must equal "
+                f"len(free_atoms)={len(free_atoms)} must equal "
                 f"len(configurations)={len(configurations)}."
             )
-        for i, (data, idx) in enumerate(zip(configurations, fixed_atoms)):
+        for i, (data, idx) in enumerate(zip(configurations, free_atoms)):
             if idx is None:
                 continue
             idx_arr = np.asarray(idx, dtype=int)
@@ -59,7 +59,7 @@ def _validate_configurations_and_fixed_atoms(
                 idx_arr.min() < 0 or idx_arr.max() >= n_atoms_i
             ):
                 raise ValueError(
-                    f"fixed_atoms[{i}] contains an out-of-range index for a "
+                    f"free_atoms[{i}] contains an out-of-range index for a "
                     f"structure with {n_atoms_i} atoms: {idx_arr.tolist()}."
                 )
 
@@ -67,7 +67,7 @@ def _validate_configurations_and_fixed_atoms(
 def minimize_energy(
     model: torch.nn.Module,
     configurations: List[AtomicData],
-    fixed_atoms: Optional[List[Optional[Sequence[int]]]] = None,
+    free_atoms: Optional[List[Optional[Sequence[int]]]] = None,
     fmax: float = 0.05,
     steps: int = 500,
     device: Union[str, torch.device] = "cpu",
@@ -76,7 +76,7 @@ def minimize_energy(
     optimizer_kwargs: Optional[Dict[str, Any]] = None,
 ) -> List[AtomicData]:
     r"""Relax all of ``configurations`` to nearby local minima of ``model`` at
-    once, optionally holding a subset of atoms fixed.
+    once, optionally restricting relaxation to a subset of atoms.
 
     The relaxation is batched: every configuration is collated into a single
     :py:class:`AtomicData` so that all structures share **one model forward
@@ -107,12 +107,14 @@ def minimize_energy(
     configurations:
         List of single, un-collated :py:class:`AtomicData` structures to
         relax. They are not modified.
-    fixed_atoms:
+    free_atoms:
         Optional list, parallel to ``configurations``, of atom index
-        sequences that should remain fixed during minimization. Use ``None``
-        for a given entry (or pass ``fixed_atoms=None`` altogether) to leave
-        that configuration fully unconstrained. Fixed atoms are held in place
-        by zeroing their gradient, so they never move.
+        sequences that are allowed to move during minimization; every other
+        atom in that structure is held fixed at its input position. Use
+        ``None`` for a given entry (or pass ``free_atoms=None`` altogether,
+        the default) to leave that configuration fully unconstrained. Fixed
+        atoms are held in place by zeroing their gradient, so they never
+        move.
     fmax:
         Convergence threshold on the largest per-atom force magnitude (atoms
         held fixed are excluded, since they are expected to carry a nonzero
@@ -156,7 +158,7 @@ def minimize_energy(
         configuration, identical to the inputs except for relaxed positions
         (cast back to each input's own dtype/device).
     """
-    _validate_configurations_and_fixed_atoms(configurations, fixed_atoms)
+    _validate_configurations_and_free_atoms(configurations, free_atoms)
 
     model = model.eval().to(device=device, dtype=dtype)
     for param in model.parameters():
@@ -177,14 +179,19 @@ def minimize_energy(
     n_atoms_total = batch.pos.shape[0]
 
     fixed_mask = torch.zeros(n_atoms_total, dtype=torch.bool, device=device)
-    if fixed_atoms is not None:
-        for i, idx in enumerate(fixed_atoms):
-            if idx is None or len(idx) == 0:
+    if free_atoms is not None:
+        for i, idx in enumerate(free_atoms):
+            if idx is None:
                 continue
-            idx_t = (
-                torch.as_tensor(idx, dtype=torch.long, device=device) + ptr[i]
-            )
-            fixed_mask[idx_t] = True
+            # Every atom in this structure starts fixed; only the listed
+            # indices (if any) are then let free again.
+            fixed_mask[ptr[i] : ptr[i + 1]] = True
+            if len(idx):
+                idx_t = (
+                    torch.as_tensor(idx, dtype=torch.long, device=device)
+                    + ptr[i]
+                )
+                fixed_mask[idx_t] = False
     # fixed_mask is static across steps; checking it every iteration would
     # cost an extra GPU->CPU sync per step for no reason.
     has_fixed = bool(fixed_mask.any())

--- a/src/mlcg/simulation/minimizer.py
+++ b/src/mlcg/simulation/minimizer.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
@@ -6,21 +7,8 @@ import torch
 from torch_geometric.data.collate import collate
 from torch_geometric.utils import scatter
 
-from ase import Atoms
-from ase.calculators.calculator import Calculator, all_changes
-from ase.constraints import FixAtoms
-from ase.optimize import FIRE
-from ase.optimize.optimize import Optimizer
-
 from ..data.atomic_data import AtomicData
-from ..data._keys import (
-    ATOM_TYPE_KEY,
-    MASS_KEY,
-    CELL_KEY,
-    PBC_KEY,
-    ENERGY_KEY,
-    FORCE_KEY,
-)
+from ..data._keys import FORCE_KEY
 
 
 def _num_structures(data: AtomicData) -> int:
@@ -41,8 +29,7 @@ def _validate_configurations_and_fixed_atoms(
     configurations: List[AtomicData],
     fixed_atoms: Optional[List[Optional[Sequence[int]]]],
 ) -> None:
-    r"""Shared input validation for :py:func:`minimize_energy` and
-    :py:func:`minimize_energy_ase`."""
+    r"""Input validation for :py:func:`minimize_energy`."""
     if len(configurations) == 0:
         raise ValueError(
             "configurations must be a non-empty list of AtomicData."
@@ -77,241 +64,6 @@ def _validate_configurations_and_fixed_atoms(
                 )
 
 
-class MLCGCalculator(Calculator):
-    r"""ASE calculator wrapper around an mlcg model.
-
-    On every :py:meth:`calculate` call, a fresh single-structure
-    :py:class:`~mlcg.data.atomic_data.AtomicData` instance is built from the
-    current :py:class:`ase.Atoms` positions and forwarded through the model to
-    obtain the energy and forces.
-
-    Parameters
-    ----------
-    model:
-        Trained mlcg model. Must be wrapped so that its output contains both
-        :py:data:`~mlcg.data._keys.ENERGY_KEY` and
-        :py:data:`~mlcg.data._keys.FORCE_KEY` (e.g. via
-        :py:class:`mlcg.nn.gradients.GradientsOut` or
-        :py:class:`mlcg.nn.gradients.SumOut`).
-    data_template:
-        A single, un-collated :py:class:`AtomicData` instance describing the
-        structure. ``atom_types``, ``masses``, ``cell``, ``pbc`` and
-        ``neighbor_list`` are captured from it once and reused, unmodified,
-        on every subsequent call; only positions change between calls.
-
-        The ``neighbor_list`` is reused verbatim rather than cleared: bonded
-        topology entries (e.g. from harmonic priors) do a direct dictionary
-        lookup with no fallback and would raise if missing, while
-        cutoff-based entries left absent from the dictionary (the standard
-        convention) are automatically rebuilt from the current positions by
-        the model itself.
-    device:
-        Device used to run the model.
-    dtype:
-        Floating point precision used to run the model.
-    """
-
-    implemented_properties = ["energy", "forces"]
-
-    def __init__(
-        self,
-        model: torch.nn.Module,
-        data_template: AtomicData,
-        device: Union[str, torch.device] = "cpu",
-        dtype: torch.dtype = torch.float32,
-        **kwargs: Any,
-    ):
-        super().__init__(**kwargs)
-        if _num_structures(data_template) != 1:
-            raise ValueError(
-                "MLCGCalculator expects a single, un-collated AtomicData "
-                f"structure, but got a template spanning "
-                f"{_num_structures(data_template)} structures."
-            )
-
-        self.model = model
-        self.device = torch.device(device)
-        self.dtype = dtype
-
-        self.atom_types = data_template.atom_types.detach().clone()
-        self.masses = (
-            data_template.masses.detach().clone()
-            if MASS_KEY in data_template and data_template.masses is not None
-            else None
-        )
-        self.cell = (
-            data_template.cell.detach().clone()
-            if CELL_KEY in data_template and data_template.cell is not None
-            else None
-        )
-        self.pbc = (
-            data_template.pbc.detach().clone()
-            if PBC_KEY in data_template and data_template.pbc is not None
-            else None
-        )
-        self.template_neighbor_list = deepcopy(data_template.neighbor_list)
-
-    def calculate(
-        self,
-        atoms: Optional[Atoms] = None,
-        properties: Sequence[str] = ("energy",),
-        system_changes: Sequence[str] = all_changes,
-    ):
-        super().calculate(atoms, properties, system_changes)
-
-        pos = torch.tensor(
-            self.atoms.get_positions(), dtype=self.dtype, device=self.device
-        )
-        data = AtomicData.from_points(
-            pos=pos,
-            atom_types=self.atom_types,
-            masses=self.masses,
-            cell=self.cell,
-            pbc=self.pbc,
-            neighborlist=deepcopy(self.template_neighbor_list),
-        )
-        batch, _, _ = collate(
-            AtomicData, data_list=[data], increment=True, add_batch=True
-        )
-        batch = batch.to(self.device)
-        batch = self.model(batch)
-
-        if FORCE_KEY not in batch.out:
-            raise KeyError(
-                f"Model output does not contain '{FORCE_KEY}'. The model "
-                "passed to MLCGCalculator/minimize_energy must be wrapped "
-                "with mlcg.nn.gradients.GradientsOut (or SumOut over "
-                "GradientsOut-wrapped terms) with forces among its targets "
-                "-- an energy-only model cannot be used for minimization."
-            )
-
-        self.results["energy"] = float(
-            batch.out[ENERGY_KEY].detach().cpu().item()
-        )
-        self.results["forces"] = (
-            batch.out[FORCE_KEY].detach().cpu().numpy().astype(np.float64)
-        )
-
-
-def minimize_energy_ase(
-    model: torch.nn.Module,
-    configurations: List[AtomicData],
-    fixed_atoms: Optional[List[Optional[Sequence[int]]]] = None,
-    optimizer_cls: Type[Optimizer] = FIRE,
-    fmax: float = 0.05,
-    steps: int = 500,
-    device: Union[str, torch.device] = "cpu",
-    dtype: torch.dtype = torch.float32,
-    optimizer_kwargs: Optional[Dict[str, Any]] = None,
-) -> List[AtomicData]:
-    r"""Relax each of ``configurations`` to a nearby local minimum of
-    ``model``, optionally holding a subset of atoms fixed.
-
-    Each configuration is minimized independently via an ASE optimizer
-    (:py:class:`ase.optimize.FIRE` by default) acting on an
-    :py:class:`MLCGCalculator`-backed :py:class:`ase.Atoms` instance. Atoms
-    marked as fixed for a given configuration are held in place via
-    :py:class:`ase.constraints.FixAtoms`.
-
-    Parameters
-    ----------
-    model:
-        Trained mlcg model producing both energies and forces (see
-        :py:class:`MLCGCalculator`). Note that this model is mutated in
-        place: it is switched to evaluation mode, moved to ``device``/``dtype``,
-        and has ``requires_grad`` disabled on all of its parameters, mirroring
-        :py:meth:`mlcg.simulation.base._Simulation._attach_model`.
-    configurations:
-        List of single, un-collated :py:class:`AtomicData` structures to
-        relax.
-    fixed_atoms:
-        Optional list, parallel to ``configurations``, of atom index
-        sequences that should remain fixed during minimization. Use ``None``
-        for a given entry (or pass ``fixed_atoms=None`` altogether) to leave
-        that configuration fully unconstrained.
-    optimizer_cls:
-        ASE :py:class:`~ase.optimize.optimize.Optimizer` subclass used to
-        perform the minimization.
-    fmax:
-        Convergence threshold on the maximum force component. This is
-        compared directly against the model's own force units (e.g.
-        kcal/mol/Angstrom for typical CG models), unlike ASE's own optimizers
-        whose default ``fmax`` assumes eV/Angstrom -- pick a value
-        appropriate for the model being used.
-    steps:
-        Maximum number of optimizer steps per configuration.
-    device:
-        Device used to run the model.
-    dtype:
-        Floating point precision used to run the model.
-    optimizer_kwargs:
-        Additional keyword arguments forwarded to ``optimizer_cls``.
-
-    Returns
-    -------
-    List[AtomicData]:
-        New list of :py:class:`AtomicData` instances, one per input
-        configuration, identical to the inputs except for relaxed positions
-        (cast back to each input's own dtype/device).
-    """
-    _validate_configurations_and_fixed_atoms(configurations, fixed_atoms)
-
-    model = model.eval().to(device=device, dtype=dtype)
-    for param in model.parameters():
-        param.requires_grad = False
-
-    optimizer_kwargs = dict(optimizer_kwargs or {})
-    optimizer_kwargs.setdefault("logfile", None)
-
-    minimized: List[AtomicData] = []
-    for i, data in enumerate(configurations):
-        calc = MLCGCalculator(model, data, device=device, dtype=dtype)
-
-        numbers = data[ATOM_TYPE_KEY].detach().cpu().numpy()
-        positions = data.pos.detach().cpu().numpy().astype(np.float64)
-        masses = (
-            data.masses.detach().cpu().numpy()
-            if MASS_KEY in data and data.masses is not None
-            else None
-        )
-        cell = (
-            data.cell.detach().cpu().numpy().reshape(3, 3)
-            if CELL_KEY in data and data.cell is not None
-            else None
-        )
-        pbc = (
-            data.pbc.detach().cpu().numpy().reshape(3)
-            if PBC_KEY in data and data.pbc is not None
-            else False
-        )
-        atoms = Atoms(
-            numbers=numbers,
-            positions=positions,
-            masses=masses,
-            cell=cell,
-            pbc=pbc,
-        )
-        atoms.calc = calc
-
-        idx = None if fixed_atoms is None else fixed_atoms[i]
-        if idx is not None and len(idx) > 0:
-            atoms.set_constraint(FixAtoms(indices=np.asarray(idx, dtype=int)))
-
-        optimizer = optimizer_cls(atoms, **optimizer_kwargs)
-        optimizer.run(fmax=fmax, steps=steps)
-
-        new_data = deepcopy(data)
-        new_data.pos = torch.tensor(
-            atoms.get_positions(),
-            dtype=data.pos.dtype,
-            device=data.pos.device,
-        )
-        new_data.out = {}
-        minimized.append(new_data)
-
-    return minimized
-
-
 def minimize_energy(
     model: torch.nn.Module,
     configurations: List[AtomicData],
@@ -323,29 +75,77 @@ def minimize_energy(
     optimizer_cls: Type[torch.optim.Optimizer] = torch.optim.LBFGS,
     optimizer_kwargs: Optional[Dict[str, Any]] = None,
 ) -> List[AtomicData]:
-    r"""Relax all of ``configurations`` at once via a batched gradient-based
-    minimization, exploiting the model's own batching: every configuration is
-    collated into a single :py:class:`AtomicData` and all structures share
-    one model forward call per step, unlike :py:func:`minimize_energy_ase`
-    which relaxes one structure at a time through ASE.
+    r"""Relax all of ``configurations`` to nearby local minima of ``model`` at
+    once, optionally holding a subset of atoms fixed.
 
-    Positions are treated as the optimizable parameters and a PyTorch
-    optimizer (``optimizer_cls``) drives the relaxation. The model forces are
-    used directly as the negative gradient of the energy with respect to
-    positions, so no second-order differentiation through the model is
-    required.
+    The relaxation is batched: every configuration is collated into a single
+    :py:class:`AtomicData` so that all structures share **one model forward
+    call per step**. Each configuration nevertheless gets its own, independent
+    ``optimizer_cls`` instance -- and therefore its own optimizer state (e.g.
+    its own L-BFGS history). That separation matters because the structures
+    are physically independent (each one's energy depends only on its own
+    coordinates), so the true Hessian is block-diagonal; a single optimizer
+    state shared across all of them would let curvature information from one
+    structure pollute the search direction chosen for the others, and would
+    need substantially more steps to reach the same ``fmax``.
+
+    The model forces are used directly as the negative gradient of the energy
+    with respect to positions, so no second-order differentiation through the
+    model is required.
 
     Parameters
     ----------
-    model, configurations, fixed_atoms, fmax, steps, device, dtype:
-        See :py:func:`minimize_energy_ase`.
+    model:
+        Trained mlcg model producing forces, i.e. wrapped so that its output
+        contains :py:data:`~mlcg.data._keys.FORCE_KEY` (via
+        :py:class:`mlcg.nn.gradients.GradientsOut`, or
+        :py:class:`mlcg.nn.gradients.SumOut` over ``GradientsOut``-wrapped
+        terms). Note that this model is mutated in place: it is switched to
+        evaluation mode, moved to ``device``/``dtype``, and has
+        ``requires_grad`` disabled on all of its parameters, mirroring
+        :py:meth:`mlcg.simulation.base._Simulation._attach_model`.
+    configurations:
+        List of single, un-collated :py:class:`AtomicData` structures to
+        relax. They are not modified.
+    fixed_atoms:
+        Optional list, parallel to ``configurations``, of atom index
+        sequences that should remain fixed during minimization. Use ``None``
+        for a given entry (or pass ``fixed_atoms=None`` altogether) to leave
+        that configuration fully unconstrained. Fixed atoms are held in place
+        by zeroing their gradient, so they never move.
+    fmax:
+        Convergence threshold on the largest per-atom force magnitude (atoms
+        held fixed are excluded, since they are expected to carry a nonzero
+        force precisely because they are being constrained). A structure is
+        considered converged once its own value drops to ``fmax`` and is then
+        left alone while the rest of the batch keeps going. This is compared
+        directly against the model's own force units (e.g. kcal/mol/Angstrom
+        for typical CG models), unlike ASE optimizers, whose default ``fmax``
+        assumes eV/Angstrom -- pick a value appropriate for the model in use.
+    steps:
+        Maximum number of optimizer steps. A warning is issued if the budget
+        runs out before every structure has converged.
+    device:
+        Device used to run the model.
+    dtype:
+        Floating point precision used to run the model. Positions are cast to
+        it for the relaxation and cast back to each input's own dtype on the
+        way out.
     optimizer_cls:
         Any :py:class:`torch.optim.Optimizer` subclass. Defaults to
         :py:class:`torch.optim.LBFGS`, which is well-suited to energy
         minimization. First-order optimizers such as
         :py:class:`torch.optim.SGD` or :py:class:`torch.optim.Adam` are also
         supported; pass optimizer-specific hyperparameters via
-        ``optimizer_kwargs``.
+        ``optimizer_kwargs``. Each ``.step()`` call is given the gradient
+        from the one forward pass already taken this iteration, via a closure
+        that does *not* re-run the model (re-running it per structure would
+        defeat the point of batching); for :py:class:`torch.optim.LBFGS` this
+        means ``max_iter`` must stay 1 (its default here), since a larger
+        value would spend extra sub-iterations applying quasi-Newton updates
+        from that same, now-stale gradient instead of a freshly evaluated
+        one. The same caveat applies to any other optimizer whose ``step()``
+        may invoke its closure more than once.
     optimizer_kwargs:
         Additional keyword arguments forwarded to ``optimizer_cls``.
 
@@ -369,6 +169,11 @@ def minimize_energy(
     batch = batch.to(device)
 
     batch_index = batch.batch
+    # ptr lives on `device`; pulling it into python once avoids a GPU->CPU
+    # sync per structure per step when it is used as a slice bound below.
+    # Also save it before the loop, since model calls may rebind batch
+    # attributes.
+    ptr = batch.ptr.tolist()
     n_atoms_total = batch.pos.shape[0]
 
     fixed_mask = torch.zeros(n_atoms_total, dtype=torch.bool, device=device)
@@ -377,29 +182,62 @@ def minimize_energy(
             if idx is None or len(idx) == 0:
                 continue
             idx_t = (
-                torch.as_tensor(idx, dtype=torch.long, device=device)
-                + batch.ptr[i]
+                torch.as_tensor(idx, dtype=torch.long, device=device) + ptr[i]
             )
             fixed_mask[idx_t] = True
+    # fixed_mask is static across steps; checking it every iteration would
+    # cost an extra GPU->CPU sync per step for no reason.
+    has_fixed = bool(fixed_mask.any())
 
-    # Positions are the only optimizable parameter; model weights stay frozen.
-    # GradientsOut internally calls torch.autograd.grad(energy, batch.pos),
-    # which does NOT set .grad; we assign pos.grad manually from the returned
-    # forces so that any torch.optim optimizer can be used without requiring
-    # a second backward pass through the model.
-    pos = batch.pos.detach().requires_grad_(True)
-    batch.pos = pos
+    # Positions are the only optimizable parameters; model weights stay
+    # frozen. GradientsOut internally calls torch.autograd.grad(energy,
+    # batch.pos), which does NOT set .grad; we assign each structure's slice
+    # of .grad manually from the returned forces so that any torch.optim
+    # optimizer can be used without requiring a second backward pass through
+    # the model. One independent leaf tensor per structure gives each one its
+    # own optimizer state (see the docstring) while the forward pass stays
+    # batched.
+    sizes = [ptr[i + 1] - ptr[i] for i in range(n_structures)]
+    param_list = [
+        p.clone().requires_grad_(True)
+        for p in batch.pos.detach().to(dtype).split(sizes)
+    ]
 
     optimizer_kwargs = dict(optimizer_kwargs or {})
-    optimizer = optimizer_cls([pos], **optimizer_kwargs)
+    # `isinstance(..., type)` first: optimizer_cls may legitimately be a
+    # partial or other factory rather than a class, and issubclass() would
+    # raise on those.
+    if isinstance(optimizer_cls, type) and issubclass(
+        optimizer_cls, torch.optim.LBFGS
+    ):
+        if optimizer_kwargs.get("max_iter", 1) != 1:
+            raise ValueError(
+                "minimize_energy's closure does not re-run the model (the "
+                "gradient for this step was already computed by the one "
+                "shared forward pass), so torch.optim.LBFGS's max_iter must "
+                "stay 1 -- see the optimizer_cls docstring entry."
+            )
+        optimizer_kwargs["max_iter"] = 1
+    optimizers = [optimizer_cls([p], **optimizer_kwargs) for p in param_list]
 
-    # Save ptr before the loop; model calls may rebind batch attributes.
-    ptr = batch.ptr
+    # Cached once: torch.optim's step() API requires a closure, but the
+    # gradient is already assigned manually from the shared forward pass
+    # below, so the closure has nothing to compute. Reusing one tensor avoids
+    # a fresh host->device scalar transfer on every one of the n_structures
+    # closure calls per step.
+    _dummy_loss = torch.tensor(0.0, dtype=dtype, device=device)
 
-    def closure() -> torch.Tensor:
-        optimizer.zero_grad()
+    def dummy_closure() -> torch.Tensor:
+        return _dummy_loss
+
+    # Structures that reach fmax are skipped for the rest of the loop: a
+    # skipped structure stops moving, so its force -- and therefore its
+    # converged status -- cannot change afterwards.
+    done = np.zeros(n_structures, dtype=bool)
+
+    for _ in range(steps):
+        batch.pos = torch.cat(param_list, dim=0)
         batch.out = {}
-        batch.pos = pos
         out = model(batch)
         if FORCE_KEY not in out.out:
             raise KeyError(
@@ -409,40 +247,47 @@ def minimize_energy(
                 "GradientsOut-wrapped terms) with forces among its targets "
                 "-- an energy-only model cannot be used for minimization."
             )
-        f = out.out[FORCE_KEY].detach()
-        g = -f
-        if fixed_mask.any():
-            g = g.masked_fill(fixed_mask.unsqueeze(1), 0.0)
-        pos.grad = g
-        if ENERGY_KEY in out.out:
-            return out.out[ENERGY_KEY].sum().detach()
-        return torch.tensor(0.0, dtype=dtype, device=device)
+        # Fresh tensor every iteration (the unary minus allocates), so it is
+        # never aliased to the model output and is safe to mask in place.
+        g = -out.out[FORCE_KEY].detach()
+        if has_fixed:
+            g.masked_fill_(fixed_mask.unsqueeze(1), 0.0)
 
-    for _ in range(steps):
-        optimizer.step(closure)
-        if pos.grad is None:
-            continue
-        # pos.grad == -forces with fixed atoms already zeroed (see closure),
-        # so its per-atom norm is the force magnitude used for convergence.
-        # Note: for line-search optimizers (e.g. LBFGS) this reflects the last
-        # closure evaluation, which may be a trial point rather than the
-        # accepted step, so the convergence estimate can be marginally noisy.
         per_structure_fmax = scatter(
-            pos.grad.detach().norm(dim=1),
+            g.norm(dim=1),
             batch_index,
             dim=0,
             dim_size=n_structures,
             reduce="max",
         )
-        if bool((per_structure_fmax <= fmax).all()):
+        # One sync for the whole per-structure array, reused for both the
+        # overall break check and the per-structure skip below, instead of a
+        # separate .all() sync plus a GPU-side compare per structure.
+        done |= (per_structure_fmax <= fmax).cpu().numpy()
+        if done.all():
             break
 
-    final_pos = pos.detach().cpu()
+        for i, opt in enumerate(optimizers):
+            if done[i]:
+                continue
+            # g is rebuilt every iteration, so this slice is never aliased or
+            # mutated across iterations -- no clone needed.
+            param_list[i].grad = g[ptr[i] : ptr[i + 1]]
+            opt.step(dummy_closure)
+    else:
+        n_unconverged = int((~done).sum())
+        if n_unconverged:
+            warnings.warn(
+                f"minimize_energy: {n_unconverged} of {n_structures} "
+                f"structure(s) did not reach fmax={fmax} within steps="
+                f"{steps}; returning their last positions."
+            )
+
+    final_pos = torch.cat(param_list, dim=0).detach().cpu()
     minimized: List[AtomicData] = []
     for i, data in enumerate(configurations):
-        start, end = int(ptr[i]), int(ptr[i + 1])
         new_data = deepcopy(data)
-        new_data.pos = final_pos[start:end].to(
+        new_data.pos = final_pos[ptr[i] : ptr[i + 1]].to(
             dtype=data.pos.dtype, device=data.pos.device
         )
         new_data.out = {}

--- a/src/mlcg/simulation/minimizer.py
+++ b/src/mlcg/simulation/minimizer.py
@@ -1,0 +1,454 @@
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Sequence, Type, Union
+
+import numpy as np
+import torch
+from torch_geometric.data.collate import collate
+from torch_geometric.utils import scatter
+
+from ase import Atoms
+from ase.calculators.calculator import Calculator, all_changes
+from ase.constraints import FixAtoms
+from ase.optimize import FIRE
+from ase.optimize.optimize import Optimizer
+
+from ..data.atomic_data import AtomicData
+from ..data._keys import (
+    ATOM_TYPE_KEY,
+    MASS_KEY,
+    CELL_KEY,
+    PBC_KEY,
+    ENERGY_KEY,
+    FORCE_KEY,
+)
+
+
+def _num_structures(data: AtomicData) -> int:
+    r"""Number of individual structures represented by an AtomicData
+    instance. ``n_atoms`` is only populated by
+    :py:meth:`AtomicData.from_points`, not by the raw ``AtomicData(...)``
+    constructor used throughout the codebase (e.g. in
+    :py:func:`mlcg.mol_utils._ASE_prior_model`), so batching is instead
+    detected the same way :py:class:`~mlcg.simulation.base._Simulation` does:
+    via the ``batch`` index added by collation.
+    """
+    if "batch" in data and data.batch is not None:
+        return int(data.batch.max().item()) + 1
+    return 1
+
+
+def _validate_configurations_and_fixed_atoms(
+    configurations: List[AtomicData],
+    fixed_atoms: Optional[List[Optional[Sequence[int]]]],
+) -> None:
+    r"""Shared input validation for :py:func:`minimize_energy` and
+    :py:func:`minimize_energy_ase`."""
+    if len(configurations) == 0:
+        raise ValueError(
+            "configurations must be a non-empty list of AtomicData."
+        )
+
+    for i, data in enumerate(configurations):
+        n_structures_i = _num_structures(data)
+        if n_structures_i != 1:
+            raise ValueError(
+                f"configurations[{i}] is batched (spans {n_structures_i} "
+                "structures); this utility expects one un-collated "
+                "AtomicData structure per list element."
+            )
+
+    if fixed_atoms is not None:
+        if len(fixed_atoms) != len(configurations):
+            raise ValueError(
+                f"len(fixed_atoms)={len(fixed_atoms)} must equal "
+                f"len(configurations)={len(configurations)}."
+            )
+        for i, (data, idx) in enumerate(zip(configurations, fixed_atoms)):
+            if idx is None:
+                continue
+            idx_arr = np.asarray(idx, dtype=int)
+            n_atoms_i = data.pos.shape[0]
+            if idx_arr.size and (
+                idx_arr.min() < 0 or idx_arr.max() >= n_atoms_i
+            ):
+                raise ValueError(
+                    f"fixed_atoms[{i}] contains an out-of-range index for a "
+                    f"structure with {n_atoms_i} atoms: {idx_arr.tolist()}."
+                )
+
+
+class MLCGCalculator(Calculator):
+    r"""ASE calculator wrapper around an mlcg model.
+
+    On every :py:meth:`calculate` call, a fresh single-structure
+    :py:class:`~mlcg.data.atomic_data.AtomicData` instance is built from the
+    current :py:class:`ase.Atoms` positions and forwarded through the model to
+    obtain the energy and forces.
+
+    Parameters
+    ----------
+    model:
+        Trained mlcg model. Must be wrapped so that its output contains both
+        :py:data:`~mlcg.data._keys.ENERGY_KEY` and
+        :py:data:`~mlcg.data._keys.FORCE_KEY` (e.g. via
+        :py:class:`mlcg.nn.gradients.GradientsOut` or
+        :py:class:`mlcg.nn.gradients.SumOut`).
+    data_template:
+        A single, un-collated :py:class:`AtomicData` instance describing the
+        structure. ``atom_types``, ``masses``, ``cell``, ``pbc`` and
+        ``neighbor_list`` are captured from it once and reused, unmodified,
+        on every subsequent call; only positions change between calls.
+
+        The ``neighbor_list`` is reused verbatim rather than cleared: bonded
+        topology entries (e.g. from harmonic priors) do a direct dictionary
+        lookup with no fallback and would raise if missing, while
+        cutoff-based entries left absent from the dictionary (the standard
+        convention) are automatically rebuilt from the current positions by
+        the model itself.
+    device:
+        Device used to run the model.
+    dtype:
+        Floating point precision used to run the model.
+    """
+
+    implemented_properties = ["energy", "forces"]
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        data_template: AtomicData,
+        device: Union[str, torch.device] = "cpu",
+        dtype: torch.dtype = torch.float32,
+        **kwargs: Any,
+    ):
+        super().__init__(**kwargs)
+        if _num_structures(data_template) != 1:
+            raise ValueError(
+                "MLCGCalculator expects a single, un-collated AtomicData "
+                f"structure, but got a template spanning "
+                f"{_num_structures(data_template)} structures."
+            )
+
+        self.model = model
+        self.device = torch.device(device)
+        self.dtype = dtype
+
+        self.atom_types = data_template.atom_types.detach().clone()
+        self.masses = (
+            data_template.masses.detach().clone()
+            if MASS_KEY in data_template and data_template.masses is not None
+            else None
+        )
+        self.cell = (
+            data_template.cell.detach().clone()
+            if CELL_KEY in data_template and data_template.cell is not None
+            else None
+        )
+        self.pbc = (
+            data_template.pbc.detach().clone()
+            if PBC_KEY in data_template and data_template.pbc is not None
+            else None
+        )
+        self.template_neighbor_list = deepcopy(data_template.neighbor_list)
+
+    def calculate(
+        self,
+        atoms: Optional[Atoms] = None,
+        properties: Sequence[str] = ("energy",),
+        system_changes: Sequence[str] = all_changes,
+    ):
+        super().calculate(atoms, properties, system_changes)
+
+        pos = torch.tensor(
+            self.atoms.get_positions(), dtype=self.dtype, device=self.device
+        )
+        data = AtomicData.from_points(
+            pos=pos,
+            atom_types=self.atom_types,
+            masses=self.masses,
+            cell=self.cell,
+            pbc=self.pbc,
+            neighborlist=deepcopy(self.template_neighbor_list),
+        )
+        batch, _, _ = collate(
+            AtomicData, data_list=[data], increment=True, add_batch=True
+        )
+        batch = batch.to(self.device)
+        batch = self.model(batch)
+
+        if FORCE_KEY not in batch.out:
+            raise KeyError(
+                f"Model output does not contain '{FORCE_KEY}'. The model "
+                "passed to MLCGCalculator/minimize_energy must be wrapped "
+                "with mlcg.nn.gradients.GradientsOut (or SumOut over "
+                "GradientsOut-wrapped terms) with forces among its targets "
+                "-- an energy-only model cannot be used for minimization."
+            )
+
+        self.results["energy"] = float(
+            batch.out[ENERGY_KEY].detach().cpu().item()
+        )
+        self.results["forces"] = (
+            batch.out[FORCE_KEY].detach().cpu().numpy().astype(np.float64)
+        )
+
+
+def minimize_energy_ase(
+    model: torch.nn.Module,
+    configurations: List[AtomicData],
+    fixed_atoms: Optional[List[Optional[Sequence[int]]]] = None,
+    optimizer_cls: Type[Optimizer] = FIRE,
+    fmax: float = 0.05,
+    steps: int = 500,
+    device: Union[str, torch.device] = "cpu",
+    dtype: torch.dtype = torch.float32,
+    optimizer_kwargs: Optional[Dict[str, Any]] = None,
+) -> List[AtomicData]:
+    r"""Relax each of ``configurations`` to a nearby local minimum of
+    ``model``, optionally holding a subset of atoms fixed.
+
+    Each configuration is minimized independently via an ASE optimizer
+    (:py:class:`ase.optimize.FIRE` by default) acting on an
+    :py:class:`MLCGCalculator`-backed :py:class:`ase.Atoms` instance. Atoms
+    marked as fixed for a given configuration are held in place via
+    :py:class:`ase.constraints.FixAtoms`.
+
+    Parameters
+    ----------
+    model:
+        Trained mlcg model producing both energies and forces (see
+        :py:class:`MLCGCalculator`). Note that this model is mutated in
+        place: it is switched to evaluation mode, moved to ``device``/``dtype``,
+        and has ``requires_grad`` disabled on all of its parameters, mirroring
+        :py:meth:`mlcg.simulation.base._Simulation._attach_model`.
+    configurations:
+        List of single, un-collated :py:class:`AtomicData` structures to
+        relax.
+    fixed_atoms:
+        Optional list, parallel to ``configurations``, of atom index
+        sequences that should remain fixed during minimization. Use ``None``
+        for a given entry (or pass ``fixed_atoms=None`` altogether) to leave
+        that configuration fully unconstrained.
+    optimizer_cls:
+        ASE :py:class:`~ase.optimize.optimize.Optimizer` subclass used to
+        perform the minimization.
+    fmax:
+        Convergence threshold on the maximum force component. This is
+        compared directly against the model's own force units (e.g.
+        kcal/mol/Angstrom for typical CG models), unlike ASE's own optimizers
+        whose default ``fmax`` assumes eV/Angstrom -- pick a value
+        appropriate for the model being used.
+    steps:
+        Maximum number of optimizer steps per configuration.
+    device:
+        Device used to run the model.
+    dtype:
+        Floating point precision used to run the model.
+    optimizer_kwargs:
+        Additional keyword arguments forwarded to ``optimizer_cls``.
+
+    Returns
+    -------
+    List[AtomicData]:
+        New list of :py:class:`AtomicData` instances, one per input
+        configuration, identical to the inputs except for relaxed positions
+        (cast back to each input's own dtype/device).
+    """
+    _validate_configurations_and_fixed_atoms(configurations, fixed_atoms)
+
+    model = model.eval().to(device=device, dtype=dtype)
+    for param in model.parameters():
+        param.requires_grad = False
+
+    optimizer_kwargs = dict(optimizer_kwargs or {})
+    optimizer_kwargs.setdefault("logfile", None)
+
+    minimized: List[AtomicData] = []
+    for i, data in enumerate(configurations):
+        calc = MLCGCalculator(model, data, device=device, dtype=dtype)
+
+        numbers = data[ATOM_TYPE_KEY].detach().cpu().numpy()
+        positions = data.pos.detach().cpu().numpy().astype(np.float64)
+        masses = (
+            data.masses.detach().cpu().numpy()
+            if MASS_KEY in data and data.masses is not None
+            else None
+        )
+        cell = (
+            data.cell.detach().cpu().numpy().reshape(3, 3)
+            if CELL_KEY in data and data.cell is not None
+            else None
+        )
+        pbc = (
+            data.pbc.detach().cpu().numpy().reshape(3)
+            if PBC_KEY in data and data.pbc is not None
+            else False
+        )
+        atoms = Atoms(
+            numbers=numbers,
+            positions=positions,
+            masses=masses,
+            cell=cell,
+            pbc=pbc,
+        )
+        atoms.calc = calc
+
+        idx = None if fixed_atoms is None else fixed_atoms[i]
+        if idx is not None and len(idx) > 0:
+            atoms.set_constraint(
+                FixAtoms(indices=np.asarray(idx, dtype=int))
+            )
+
+        optimizer = optimizer_cls(atoms, **optimizer_kwargs)
+        optimizer.run(fmax=fmax, steps=steps)
+
+        new_data = deepcopy(data)
+        new_data.pos = torch.tensor(
+            atoms.get_positions(),
+            dtype=data.pos.dtype,
+            device=data.pos.device,
+        )
+        new_data.out = {}
+        minimized.append(new_data)
+
+    return minimized
+
+
+
+def minimize_energy(
+    model: torch.nn.Module,
+    configurations: List[AtomicData],
+    fixed_atoms: Optional[List[Optional[Sequence[int]]]] = None,
+    fmax: float = 0.05,
+    steps: int = 500,
+    device: Union[str, torch.device] = "cpu",
+    dtype: torch.dtype = torch.float32,
+    optimizer_cls: Type[torch.optim.Optimizer] = torch.optim.LBFGS,
+    optimizer_kwargs: Optional[Dict[str, Any]] = None,
+) -> List[AtomicData]:
+    r"""Relax all of ``configurations`` at once via a batched gradient-based
+    minimization, exploiting the model's own batching: every configuration is
+    collated into a single :py:class:`AtomicData` and all structures share
+    one model forward call per step, unlike :py:func:`minimize_energy_ase`
+    which relaxes one structure at a time through ASE.
+
+    Positions are treated as the optimizable parameters and a PyTorch
+    optimizer (``optimizer_cls``) drives the relaxation. The model forces are
+    used directly as the negative gradient of the energy with respect to
+    positions, so no second-order differentiation through the model is
+    required.
+
+    Parameters
+    ----------
+    model, configurations, fixed_atoms, fmax, steps, device, dtype:
+        See :py:func:`minimize_energy_ase`.
+    optimizer_cls:
+        Any :py:class:`torch.optim.Optimizer` subclass. Defaults to
+        :py:class:`torch.optim.LBFGS`, which is well-suited to energy
+        minimization. First-order optimizers such as
+        :py:class:`torch.optim.SGD` or :py:class:`torch.optim.Adam` are also
+        supported; pass optimizer-specific hyperparameters via
+        ``optimizer_kwargs``.
+    optimizer_kwargs:
+        Additional keyword arguments forwarded to ``optimizer_cls``.
+
+    Returns
+    -------
+    List[AtomicData]:
+        New list of :py:class:`AtomicData` instances, one per input
+        configuration, identical to the inputs except for relaxed positions
+        (cast back to each input's own dtype/device).
+    """
+    _validate_configurations_and_fixed_atoms(configurations, fixed_atoms)
+
+    model = model.eval().to(device=device, dtype=dtype)
+    for param in model.parameters():
+        param.requires_grad = False
+
+    n_structures = len(configurations)
+    batch, _, _ = collate(
+        AtomicData, data_list=configurations, increment=True, add_batch=True
+    )
+    batch = batch.to(device)
+
+    batch_index = batch.batch
+    n_atoms_total = batch.pos.shape[0]
+
+    fixed_mask = torch.zeros(n_atoms_total, dtype=torch.bool, device=device)
+    if fixed_atoms is not None:
+        for i, idx in enumerate(fixed_atoms):
+            if idx is None or len(idx) == 0:
+                continue
+            idx_t = (
+                torch.as_tensor(idx, dtype=torch.long, device=device)
+                + batch.ptr[i]
+            )
+            fixed_mask[idx_t] = True
+
+    # Positions are the only optimizable parameter; model weights stay frozen.
+    # GradientsOut internally calls torch.autograd.grad(energy, batch.pos),
+    # which does NOT set .grad; we assign pos.grad manually from the returned
+    # forces so that any torch.optim optimizer can be used without requiring
+    # a second backward pass through the model.
+    pos = batch.pos.detach().requires_grad_(True)
+    batch.pos = pos
+
+    optimizer_kwargs = dict(optimizer_kwargs or {})
+    optimizer = optimizer_cls([pos], **optimizer_kwargs)
+
+    # Save ptr before the loop; model calls may rebind batch attributes.
+    ptr = batch.ptr
+
+    def closure() -> torch.Tensor:
+        optimizer.zero_grad()
+        batch.out = {}
+        batch.pos = pos
+        out = model(batch)
+        if FORCE_KEY not in out.out:
+            raise KeyError(
+                f"Model output does not contain \'{FORCE_KEY}\'. The model "
+                "passed to minimize_energy must be wrapped with "
+                "mlcg.nn.gradients.GradientsOut (or SumOut over "
+                "GradientsOut-wrapped terms) with forces among its targets "
+                "-- an energy-only model cannot be used for minimization."
+            )
+        f = out.out[FORCE_KEY].detach()
+        g = -f
+        if fixed_mask.any():
+            g = g.masked_fill(fixed_mask.unsqueeze(1), 0.0)
+        pos.grad = g
+        if ENERGY_KEY in out.out:
+            return out.out[ENERGY_KEY].sum().detach()
+        return torch.tensor(0.0, dtype=dtype, device=device)
+
+    for _ in range(steps):
+        optimizer.step(closure)
+        if pos.grad is None:
+            continue
+        # pos.grad == -forces with fixed atoms already zeroed (see closure),
+        # so its per-atom norm is the force magnitude used for convergence.
+        # Note: for line-search optimizers (e.g. LBFGS) this reflects the last
+        # closure evaluation, which may be a trial point rather than the
+        # accepted step, so the convergence estimate can be marginally noisy.
+        per_structure_fmax = scatter(
+            pos.grad.detach().norm(dim=1),
+            batch_index,
+            dim=0,
+            dim_size=n_structures,
+            reduce="max",
+        )
+        if bool((per_structure_fmax <= fmax).all()):
+            break
+
+    final_pos = pos.detach().cpu()
+    minimized: List[AtomicData] = []
+    for i, data in enumerate(configurations):
+        start, end = int(ptr[i]), int(ptr[i + 1])
+        new_data = deepcopy(data)
+        new_data.pos = final_pos[start:end].to(
+            dtype=data.pos.dtype, device=data.pos.device
+        )
+        new_data.out = {}
+        minimized.append(new_data)
+
+    return minimized

--- a/tests/unit/simulation/test_minimizer.py
+++ b/tests/unit/simulation/test_minimizer.py
@@ -1,0 +1,144 @@
+import numpy as np
+import pytest
+import torch
+from torch_geometric.data.collate import collate
+
+from mlcg.data.atomic_data import AtomicData
+from mlcg.data._keys import ENERGY_KEY
+from mlcg.mol_utils import _ASE_prior_model
+from mlcg.simulation.minimizer import (
+    minimize_energy,
+    minimize_energy_ase,
+)
+
+
+@pytest.fixture
+def ASE_prior_model():
+    return _ASE_prior_model
+
+
+def _build_perturbed_configurations(
+    data_dictionary, n_configs=3, scale=0.2, seed=0
+):
+    """Builds a list of un-collated AtomicData instances by perturbing the
+    equilibrium ASE geometry with small Gaussian noise."""
+    mol = data_dictionary["molecule"]
+    neighbor_lists = data_dictionary["neighbor_lists"]
+    rng = np.random.default_rng(seed)
+    equilibrium_coords = np.array(mol.get_positions())
+
+    configurations = []
+    for _ in range(n_configs):
+        perturbed_coords = equilibrium_coords + scale * rng.standard_normal(
+            equilibrium_coords.shape
+        )
+        configurations.append(
+            AtomicData(
+                pos=torch.tensor(perturbed_coords).float(),
+                atom_types=torch.tensor(mol.get_atomic_numbers()),
+                masses=torch.tensor(mol.get_masses()).float(),
+                cell=None,
+                neighbor_list=neighbor_lists,
+            )
+        )
+    return configurations
+
+
+def _energy(model, data):
+    batch, _, _ = collate(
+        AtomicData, data_list=[data], increment=True, add_batch=True
+    )
+    batch = model(batch)
+    return batch.out[ENERGY_KEY].detach().item()
+
+
+def test_minimize_energy_decreases_energy(ASE_prior_model):
+    # Batched torch minimizer.
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+
+    initial_energies = [_energy(model, data) for data in configurations]
+    minimized = minimize_energy(model, configurations, fmax=1e-3, steps=200)
+    final_energies = [_energy(model, data) for data in minimized]
+
+    for initial, final in zip(initial_energies, final_energies):
+        assert final < initial
+
+
+def test_minimize_energy_ase_decreases_energy(ASE_prior_model):
+    # ASE-driven minimizer.
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+
+    initial_energies = [_energy(model, data) for data in configurations]
+    minimized = minimize_energy_ase(model, configurations, fmax=1e-3, steps=200)
+    final_energies = [_energy(model, data) for data in minimized]
+
+    for initial, final in zip(initial_energies, final_energies):
+        assert final < initial
+
+
+@pytest.mark.parametrize("minimizer", [minimize_energy, minimize_energy_ase])
+def test_converges_near_equilibrium(ASE_prior_model, minimizer):
+    # The bonded prior is invariant to rigid-body motion, so relaxation can
+    # introduce a small whole-molecule drift relative to the original ASE
+    # frame. Rather than asserting an absolute RMSD to that frame, check that
+    # minimization moves each configuration closer to it than it started.
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    mol = data_dictionary["molecule"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+
+    equilibrium_coords = torch.tensor(mol.get_positions()).float()
+    initial_rmsds = [
+        torch.sqrt(torch.mean((data.pos - equilibrium_coords) ** 2))
+        for data in configurations
+    ]
+
+    minimized = minimizer(model, configurations, fmax=1e-3, steps=200)
+
+    for initial_rmsd, data in zip(initial_rmsds, minimized):
+        final_rmsd = torch.sqrt(
+            torch.mean((data.pos - equilibrium_coords) ** 2)
+        )
+        assert final_rmsd < initial_rmsd
+
+
+@pytest.mark.parametrize("minimizer", [minimize_energy, minimize_energy_ase])
+def test_fixed_atoms_do_not_move(ASE_prior_model, minimizer):
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+    original_positions = [data.pos.clone() for data in configurations]
+
+    fixed_atoms = [[0] for _ in configurations]
+    minimized = minimizer(
+        model, configurations, fixed_atoms=fixed_atoms, fmax=1e-3, steps=200
+    )
+
+    for original, data in zip(original_positions, minimized):
+        assert torch.allclose(data.pos[0], original[0], atol=1e-6)
+        assert not torch.allclose(data.pos[1:], original[1:], atol=1e-3)
+
+
+def test_both_minimizers_agree(ASE_prior_model):
+    # From the same starting geometries and a tight force tolerance, the
+    # batched torch minimizer and the ASE minimizer must relax to the same
+    # local minimum. The bonded prior is invariant to rigid-body motion, so
+    # the two optimizers can leave the molecule at slightly different overall
+    # positions/orientations; compare the (invariant) minimized energies.
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+
+    minimized = minimize_energy(model, configurations, fmax=1e-5, steps=500)
+    minimized_ase = minimize_energy_ase(
+        model, configurations, fmax=1e-5, steps=500
+    )
+
+    for data, data_ase in zip(minimized, minimized_ase):
+        np.testing.assert_allclose(
+            _energy(model, data), _energy(model, data_ase), rtol=1e-4
+        )

--- a/tests/unit/simulation/test_minimizer.py
+++ b/tests/unit/simulation/test_minimizer.py
@@ -117,15 +117,20 @@ def test_converges_near_equilibrium(ASE_prior_model):
         assert final_rmsd < initial_rmsd
 
 
-def test_fixed_atoms_do_not_move(ASE_prior_model):
+def test_atoms_outside_free_atoms_do_not_move(ASE_prior_model):
     data_dictionary = ASE_prior_model()
     model = data_dictionary["model"]
     configurations = _build_perturbed_configurations(data_dictionary)
     original_positions = [data.pos.clone() for data in configurations]
+    n_atoms = configurations[0].pos.shape[0]
 
-    fixed_atoms = [[0] for _ in configurations]
+    free = [i for i in range(n_atoms) if i != 0]
     minimized = minimize_energy(
-        model, configurations, fixed_atoms=fixed_atoms, fmax=1e-3, steps=200
+        model,
+        configurations,
+        free_atoms=[free for _ in configurations],
+        fmax=1e-3,
+        steps=200,
     )
 
     for original, data in zip(original_positions, minimized):
@@ -133,7 +138,7 @@ def test_fixed_atoms_do_not_move(ASE_prior_model):
         assert not torch.allclose(data.pos[1:], original[1:], atol=1e-3)
 
 
-def test_fixed_atoms_excluded_from_convergence(ASE_prior_model):
+def test_non_free_atoms_excluded_from_convergence(ASE_prior_model):
     # A fixed atom keeps a large force, so convergence must be judged on the
     # free atoms alone -- otherwise no constrained run could ever converge.
     data_dictionary = ASE_prior_model()
@@ -141,13 +146,12 @@ def test_fixed_atoms_excluded_from_convergence(ASE_prior_model):
     configurations = _build_perturbed_configurations(data_dictionary)
     n_atoms = configurations[0].pos.shape[0]
 
-    fixed = [0]
-    free = [i for i in range(n_atoms) if i not in fixed]
+    free = [i for i in range(n_atoms) if i != 0]
     fmax = 1e-3
     minimized = minimize_energy(
         model,
         configurations,
-        fixed_atoms=[fixed for _ in configurations],
+        free_atoms=[free for _ in configurations],
         fmax=fmax,
         steps=500,
     )
@@ -320,7 +324,7 @@ def test_rejects_batched_configuration(ASE_prior_model):
         minimize_energy(model, [batched], fmax=1e-3, steps=10)
 
 
-def test_rejects_out_of_range_fixed_atoms(ASE_prior_model):
+def test_rejects_out_of_range_free_atoms(ASE_prior_model):
     data_dictionary = ASE_prior_model()
     model = data_dictionary["model"]
     configurations = _build_perturbed_configurations(data_dictionary)
@@ -330,7 +334,7 @@ def test_rejects_out_of_range_fixed_atoms(ASE_prior_model):
         minimize_energy(
             model,
             configurations,
-            fixed_atoms=[[n_atoms] for _ in configurations],
+            free_atoms=[[n_atoms] for _ in configurations],
             fmax=1e-3,
             steps=10,
         )

--- a/tests/unit/simulation/test_minimizer.py
+++ b/tests/unit/simulation/test_minimizer.py
@@ -1,15 +1,14 @@
+import warnings
+
 import numpy as np
 import pytest
 import torch
 from torch_geometric.data.collate import collate
 
 from mlcg.data.atomic_data import AtomicData
-from mlcg.data._keys import ENERGY_KEY
+from mlcg.data._keys import ENERGY_KEY, FORCE_KEY
 from mlcg.mol_utils import _ASE_prior_model
-from mlcg.simulation.minimizer import (
-    minimize_energy,
-    minimize_energy_ase,
-)
+from mlcg.simulation.minimizer import minimize_energy
 
 
 @pytest.fixture
@@ -44,16 +43,29 @@ def _build_perturbed_configurations(
     return configurations
 
 
-def _energy(model, data):
+def _forward(model, data):
     batch, _, _ = collate(
         AtomicData, data_list=[data], increment=True, add_batch=True
     )
-    batch = model(batch)
-    return batch.out[ENERGY_KEY].detach().item()
+    return model(batch).out
+
+
+def _energy(model, data):
+    return _forward(model, data)[ENERGY_KEY].detach().item()
+
+
+def _max_force(model, data, atom_indices=None):
+    """Largest per-atom force magnitude, optionally restricted to a subset of
+    atoms. Fixed atoms are expected to carry a large force -- that is what
+    holding them away from their unconstrained equilibrium means -- so they
+    must be excluded when checking convergence."""
+    forces = _forward(model, data)[FORCE_KEY].detach().norm(dim=1)
+    if atom_indices is not None:
+        forces = forces[torch.as_tensor(atom_indices, dtype=torch.long)]
+    return forces.max().item()
 
 
 def test_minimize_energy_decreases_energy(ASE_prior_model):
-    # Batched torch minimizer.
     data_dictionary = ASE_prior_model()
     model = data_dictionary["model"]
     configurations = _build_perturbed_configurations(data_dictionary)
@@ -66,22 +78,21 @@ def test_minimize_energy_decreases_energy(ASE_prior_model):
         assert final < initial
 
 
-def test_minimize_energy_ase_decreases_energy(ASE_prior_model):
-    # ASE-driven minimizer.
+def test_reaches_fmax(ASE_prior_model):
+    # The documented contract: on return, every structure's largest per-atom
+    # force is at or below fmax.
     data_dictionary = ASE_prior_model()
     model = data_dictionary["model"]
     configurations = _build_perturbed_configurations(data_dictionary)
 
-    initial_energies = [_energy(model, data) for data in configurations]
-    minimized = minimize_energy_ase(model, configurations, fmax=1e-3, steps=200)
-    final_energies = [_energy(model, data) for data in minimized]
+    fmax = 1e-3
+    minimized = minimize_energy(model, configurations, fmax=fmax, steps=500)
 
-    for initial, final in zip(initial_energies, final_energies):
-        assert final < initial
+    for data in minimized:
+        assert _max_force(model, data) <= fmax
 
 
-@pytest.mark.parametrize("minimizer", [minimize_energy, minimize_energy_ase])
-def test_converges_near_equilibrium(ASE_prior_model, minimizer):
+def test_converges_near_equilibrium(ASE_prior_model):
     # The bonded prior is invariant to rigid-body motion, so relaxation can
     # introduce a small whole-molecule drift relative to the original ASE
     # frame. Rather than asserting an absolute RMSD to that frame, check that
@@ -97,7 +108,7 @@ def test_converges_near_equilibrium(ASE_prior_model, minimizer):
         for data in configurations
     ]
 
-    minimized = minimizer(model, configurations, fmax=1e-3, steps=200)
+    minimized = minimize_energy(model, configurations, fmax=1e-3, steps=200)
 
     for initial_rmsd, data in zip(initial_rmsds, minimized):
         final_rmsd = torch.sqrt(
@@ -106,15 +117,14 @@ def test_converges_near_equilibrium(ASE_prior_model, minimizer):
         assert final_rmsd < initial_rmsd
 
 
-@pytest.mark.parametrize("minimizer", [minimize_energy, minimize_energy_ase])
-def test_fixed_atoms_do_not_move(ASE_prior_model, minimizer):
+def test_fixed_atoms_do_not_move(ASE_prior_model):
     data_dictionary = ASE_prior_model()
     model = data_dictionary["model"]
     configurations = _build_perturbed_configurations(data_dictionary)
     original_positions = [data.pos.clone() for data in configurations]
 
     fixed_atoms = [[0] for _ in configurations]
-    minimized = minimizer(
+    minimized = minimize_energy(
         model, configurations, fixed_atoms=fixed_atoms, fmax=1e-3, steps=200
     )
 
@@ -123,22 +133,204 @@ def test_fixed_atoms_do_not_move(ASE_prior_model, minimizer):
         assert not torch.allclose(data.pos[1:], original[1:], atol=1e-3)
 
 
-def test_both_minimizers_agree(ASE_prior_model):
-    # From the same starting geometries and a tight force tolerance, the
-    # batched torch minimizer and the ASE minimizer must relax to the same
-    # local minimum. The bonded prior is invariant to rigid-body motion, so
-    # the two optimizers can leave the molecule at slightly different overall
-    # positions/orientations; compare the (invariant) minimized energies.
+def test_fixed_atoms_excluded_from_convergence(ASE_prior_model):
+    # A fixed atom keeps a large force, so convergence must be judged on the
+    # free atoms alone -- otherwise no constrained run could ever converge.
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+    n_atoms = configurations[0].pos.shape[0]
+
+    fixed = [0]
+    free = [i for i in range(n_atoms) if i not in fixed]
+    fmax = 1e-3
+    minimized = minimize_energy(
+        model,
+        configurations,
+        fixed_atoms=[fixed for _ in configurations],
+        fmax=fmax,
+        steps=500,
+    )
+
+    for data in minimized:
+        assert _max_force(model, data, atom_indices=free) <= fmax
+
+
+def test_inputs_are_not_mutated(ASE_prior_model):
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+    original_positions = [data.pos.clone() for data in configurations]
+
+    minimize_energy(model, configurations, fmax=1e-3, steps=50)
+
+    for original, data in zip(original_positions, configurations):
+        assert torch.equal(data.pos, original)
+
+
+def test_lbfgs_max_iter_guard(ASE_prior_model):
+    # torch.optim.LBFGS's closure here does not re-run the model, so more than
+    # one inner iteration would reuse a stale gradient.
     data_dictionary = ASE_prior_model()
     model = data_dictionary["model"]
     configurations = _build_perturbed_configurations(data_dictionary)
 
-    minimized = minimize_energy(model, configurations, fmax=1e-5, steps=500)
-    minimized_ase = minimize_energy_ase(
-        model, configurations, fmax=1e-5, steps=500
+    with pytest.raises(ValueError, match="max_iter"):
+        minimize_energy(
+            model,
+            configurations,
+            fmax=1e-3,
+            steps=10,
+            optimizer_cls=torch.optim.LBFGS,
+            optimizer_kwargs={"max_iter": 5},
+        )
+
+
+@pytest.mark.parametrize(
+    "optimizer_cls, optimizer_kwargs",
+    [
+        (torch.optim.SGD, {"lr": 1e-3}),
+        (torch.optim.Adam, {"lr": 1e-3}),
+    ],
+)
+def test_other_optimizers_supported(
+    ASE_prior_model, optimizer_cls, optimizer_kwargs
+):
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+
+    initial_energies = [_energy(model, data) for data in configurations]
+    minimized = minimize_energy(
+        model,
+        configurations,
+        fmax=1e-3,
+        steps=200,
+        optimizer_cls=optimizer_cls,
+        optimizer_kwargs=optimizer_kwargs,
+    )
+    final_energies = [_energy(model, data) for data in minimized]
+
+    for initial, final in zip(initial_energies, final_energies):
+        assert final < initial
+
+
+def test_converged_structures_stop_being_stepped(ASE_prior_model):
+    # The design relies on skipping a structure's optimizer once it reaches
+    # fmax, while the rest of the batch keeps going. Verify that directly by
+    # counting each structure's own optimizer.step() calls, rather than
+    # inferring it indirectly from the final positions.
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    # scale=0: exactly at equilibrium, converges within very few steps (or
+    # zero). A heavily perturbed sibling needs many more.
+    easy = _build_perturbed_configurations(
+        data_dictionary, n_configs=1, scale=0.0
+    )
+    hard = _build_perturbed_configurations(
+        data_dictionary, n_configs=1, scale=0.5, seed=1
+    )
+    configurations = easy + hard
+
+    step_counts = []
+
+    class CountingLBFGS(torch.optim.LBFGS):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            step_counts.append(0)
+            self._slot = len(step_counts) - 1
+
+        def step(self, closure=None):
+            step_counts[self._slot] += 1
+            return super().step(closure)
+
+    minimize_energy(
+        model,
+        configurations,
+        fmax=0.05,
+        steps=300,
+        optimizer_cls=CountingLBFGS,
+        optimizer_kwargs={"max_iter": 1},
     )
 
-    for data, data_ase in zip(minimized, minimized_ase):
-        np.testing.assert_allclose(
-            _energy(model, data), _energy(model, data_ase), rtol=1e-4
+    assert len(step_counts) == 2
+    easy_steps, hard_steps = step_counts
+    assert (
+        hard_steps > 0
+    ), "the perturbed structure should need at least one step"
+    assert easy_steps < hard_steps, (
+        f"expected the near-equilibrium structure ({easy_steps} steps) to stop "
+        f"well before the perturbed one ({hard_steps} steps)"
+    )
+
+
+def test_structures_converge_independently_within_a_mixed_batch(
+    ASE_prior_model,
+):
+    # A structure's convergence must not depend on how far the others in the
+    # same batch are from their own fmax.
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    easy = _build_perturbed_configurations(
+        data_dictionary, n_configs=1, scale=0.05, seed=2
+    )
+    hard = _build_perturbed_configurations(
+        data_dictionary, n_configs=1, scale=0.5, seed=1
+    )
+    configurations = easy + hard
+
+    fmax = 1e-3
+    minimized = minimize_energy(model, configurations, fmax=fmax, steps=1000)
+
+    for data in minimized:
+        assert _max_force(model, data) <= fmax
+
+
+def test_warns_when_steps_exhausted_before_convergence(ASE_prior_model):
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+
+    # An unreachable fmax with almost no step budget guarantees the run ends
+    # unconverged regardless of starting geometry, so this warning is
+    # deterministic rather than borderline.
+    with pytest.warns(UserWarning, match="did not reach fmax"):
+        minimize_energy(model, configurations, fmax=1e-8, steps=3)
+
+    # The same (fmax, steps) as test_reaches_fmax, which is proven to
+    # converge -- so this warning would be a regression, not noise. Record
+    # rather than escalate every warning to an error: unrelated code (e.g.
+    # a torch indexing deprecation warning inside the harmonic prior) fires
+    # on every forward pass and must not fail this test.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        minimize_energy(model, configurations, fmax=1e-3, steps=500)
+    assert not any("did not reach fmax" in str(w.message) for w in caught)
+
+
+def test_rejects_batched_configuration(ASE_prior_model):
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+    batched, _, _ = collate(
+        AtomicData, data_list=configurations, increment=True, add_batch=True
+    )
+
+    with pytest.raises(ValueError, match="batched"):
+        minimize_energy(model, [batched], fmax=1e-3, steps=10)
+
+
+def test_rejects_out_of_range_fixed_atoms(ASE_prior_model):
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+    n_atoms = configurations[0].pos.shape[0]
+
+    with pytest.raises(ValueError, match="out-of-range"):
+        minimize_energy(
+            model,
+            configurations,
+            fixed_atoms=[[n_atoms] for _ in configurations],
+            fmax=1e-3,
+            steps=10,
         )


### PR DESCRIPTION
# PR Checklist

- [] Bug fix
- [x] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

Adds utilities to relax coarse-grained configurations to a local energy minimum of a trained mlcg model.

What's added (src/mlcg/simulation/minimizer.py):

minimize_energy: batched minimization. All configurations are collated into a single batch and relaxed together with one model forward call per step, using a torch.optim optimizer (LBFGS by default). Model forces are used directly as the negative energy gradient, so no second backward pass is needed.

minimize_energy_ase: relaxes one structure at a time through an ASE optimizer (FIRE by default)

MLCGCalculator: an ASE Calculator wrapper that evaluates energies/forces from an mlcg model, needed for minimize_energy_ase.

Both support per-configuration fixed atoms (frozen during relaxation) and share the same input validation and convergence criterion (max per-atom force magnitude vs fmax).

Tests (tests/unit/simulation/test_minimizer.py): each minimizer is checked for energy decrease, convergence toward equilibrium, and fixed-atom immobility, plus a test that the two methods converge to the same minimum.

Notes: On a real system the batched path was ~15–18× faster than the sequential ASE path while producing matching geometries.