### PR TITLE
Add batch_size chunking and flat free_atoms broadcasting to minimize_…

### DIFF
--- a/src/mlcg/simulation/minimizer.py
+++ b/src/mlcg/simulation/minimizer.py
@@ -25,6 +25,19 @@ def _num_structures(data: AtomicData) -> int:
     return 1
 
 
+def _broadcast_free_atoms(
+    free_atoms: Optional[List[Any]], n_structures: int
+) -> Optional[List[Optional[Sequence[int]]]]:
+    r"""If ``free_atoms`` is a single flat list of atom indices, repeat it
+    once per structure; otherwise (already one list per structure, or
+    ``None``) return it unchanged. A flat list is recognized by its first
+    element being a plain index rather than a sequence/``None``.
+    """
+    if free_atoms and isinstance(free_atoms[0], (int, np.integer)):
+        return [free_atoms] * n_structures
+    return free_atoms
+
+
 def _validate_configurations_and_free_atoms(
     configurations: List[AtomicData],
     free_atoms: Optional[List[Optional[Sequence[int]]]],
@@ -67,13 +80,14 @@ def _validate_configurations_and_free_atoms(
 def minimize_energy(
     model: torch.nn.Module,
     configurations: List[AtomicData],
-    free_atoms: Optional[List[Optional[Sequence[int]]]] = None,
+    free_atoms: Optional[List[Any]] = None,
     fmax: float = 0.05,
     steps: int = 500,
     device: Union[str, torch.device] = "cpu",
     dtype: torch.dtype = torch.float32,
     optimizer_cls: Type[torch.optim.Optimizer] = torch.optim.LBFGS,
     optimizer_kwargs: Optional[Dict[str, Any]] = None,
+    batch_size: Optional[int] = None,
 ) -> List[AtomicData]:
     r"""Relax all of ``configurations`` to nearby local minima of ``model`` at
     once, optionally restricting relaxation to a subset of atoms.
@@ -108,13 +122,13 @@ def minimize_energy(
         List of single, un-collated :py:class:`AtomicData` structures to
         relax. They are not modified.
     free_atoms:
-        Optional list, parallel to ``configurations``, of atom index
-        sequences that are allowed to move during minimization; every other
-        atom in that structure is held fixed at its input position. Use
-        ``None`` for a given entry (or pass ``free_atoms=None`` altogether,
-        the default) to leave that configuration fully unconstrained. Fixed
-        atoms are held in place by zeroing their gradient, so they never
-        move.
+        Optional atom indices allowed to move during minimization; every
+        other atom is held fixed at its input position. Either a single
+        flat list of indices, applied to every one of ``configurations``
+        alike, or a list with one (optional) index list per configuration
+        for when structures need different atoms free (``None`` for an
+        entry leaves that configuration fully unconstrained). Pass
+        ``free_atoms=None`` (the default) to leave everything unconstrained.
     fmax:
         Convergence threshold on the largest per-atom force magnitude (atoms
         held fixed are excluded, since they are expected to carry a nonzero
@@ -150,6 +164,17 @@ def minimize_energy(
         may invoke its closure more than once.
     optimizer_kwargs:
         Additional keyword arguments forwarded to ``optimizer_cls``.
+    batch_size:
+        Maximum number of structures collated into a single forward pass.
+        ``configurations`` is split into consecutive chunks of at most this
+        size, each relaxed independently (as if by its own
+        :py:func:`minimize_energy` call) with the results concatenated back
+        together -- lower peak memory at the cost of running more, smaller
+        forward passes rather than one large one. ``None`` (the default)
+        keeps the original behavior of collating everything at once. A
+        structure's convergence and step budget are tracked only within its
+        own chunk, so an unconverged-structures warning may fire once per
+        affected chunk rather than once overall.
 
     Returns
     -------
@@ -158,12 +183,52 @@ def minimize_energy(
         configuration, identical to the inputs except for relaxed positions
         (cast back to each input's own dtype/device).
     """
+    free_atoms = _broadcast_free_atoms(free_atoms, len(configurations))
     _validate_configurations_and_free_atoms(configurations, free_atoms)
+    if batch_size is not None and batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}.")
 
     model = model.eval().to(device=device, dtype=dtype)
     for param in model.parameters():
         param.requires_grad = False
 
+    chunk_size = batch_size or len(configurations)
+    minimized: List[AtomicData] = []
+    for start in range(0, len(configurations), chunk_size):
+        end = start + chunk_size
+        minimized.extend(
+            _minimize_energy_batch(
+                model,
+                configurations[start:end],
+                free_atoms[start:end] if free_atoms is not None else None,
+                fmax=fmax,
+                steps=steps,
+                device=device,
+                dtype=dtype,
+                optimizer_cls=optimizer_cls,
+                optimizer_kwargs=optimizer_kwargs,
+            )
+        )
+    return minimized
+
+
+def _minimize_energy_batch(
+    model: torch.nn.Module,
+    configurations: List[AtomicData],
+    free_atoms: Optional[List[Optional[Sequence[int]]]],
+    fmax: float,
+    steps: int,
+    device: Union[str, torch.device],
+    dtype: torch.dtype,
+    optimizer_cls: Type[torch.optim.Optimizer],
+    optimizer_kwargs: Optional[Dict[str, Any]],
+) -> List[AtomicData]:
+    r"""One chunk of :py:func:`minimize_energy`'s work: collates
+    ``configurations`` into a single batch and relaxes all of them with one
+    model forward call per step. ``model`` is assumed already prepared
+    (eval mode, moved to ``device``/``dtype``, gradients disabled) and
+    ``free_atoms`` already validated and in its per-structure form.
+    """
     n_structures = len(configurations)
     batch, _, _ = collate(
         AtomicData, data_list=configurations, increment=True, add_batch=True

--- a/tests/unit/simulation/test_minimizer.py
+++ b/tests/unit/simulation/test_minimizer.py
@@ -160,6 +160,79 @@ def test_non_free_atoms_excluded_from_convergence(ASE_prior_model):
         assert _max_force(model, data, atom_indices=free) <= fmax
 
 
+def test_flat_free_atoms_broadcasts_to_every_structure(ASE_prior_model):
+    # A single flat sequence (rather than one entry per structure) should
+    # apply to every structure alike.
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+    original_positions = [data.pos.clone() for data in configurations]
+    n_atoms = configurations[0].pos.shape[0]
+
+    free = [i for i in range(n_atoms) if i != 0]
+    minimized = minimize_energy(
+        model, configurations, free_atoms=free, fmax=1e-3, steps=200
+    )
+
+    for original, data in zip(original_positions, minimized):
+        assert torch.allclose(data.pos[0], original[0], atol=1e-6)
+        assert not torch.allclose(data.pos[1:], original[1:], atol=1e-3)
+
+
+def test_flat_free_atoms_matches_explicit_per_structure_list(ASE_prior_model):
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+    n_atoms = configurations[0].pos.shape[0]
+    free = [i for i in range(n_atoms) if i != 0]
+
+    flat = minimize_energy(
+        model, configurations, free_atoms=free, fmax=1e-3, steps=200
+    )
+    explicit = minimize_energy(
+        model,
+        configurations,
+        free_atoms=[free for _ in configurations],
+        fmax=1e-3,
+        steps=200,
+    )
+
+    for a, b in zip(flat, explicit):
+        assert torch.equal(a.pos, b.pos)
+
+
+def test_batch_size_matches_unchunked_result(ASE_prior_model):
+    # Chunking is purely a memory-management device: each structure's own
+    # relaxation is independent of what else shares its batch, so the result
+    # for a given batch_size should closely match one big batch (not
+    # bit-identical, since collating a different set of structures changes
+    # floating point summation order within the model/LBFGS internals).
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(
+        data_dictionary, n_configs=5
+    )
+
+    unchunked = minimize_energy(model, configurations, fmax=1e-3, steps=200)
+    chunked = minimize_energy(
+        model, configurations, fmax=1e-3, steps=200, batch_size=2
+    )
+
+    for a, b in zip(unchunked, chunked):
+        assert torch.allclose(a.pos, b.pos, atol=1e-2)
+
+
+def test_rejects_non_positive_batch_size(ASE_prior_model):
+    data_dictionary = ASE_prior_model()
+    model = data_dictionary["model"]
+    configurations = _build_perturbed_configurations(data_dictionary)
+
+    with pytest.raises(ValueError, match="batch_size"):
+        minimize_energy(
+            model, configurations, fmax=1e-3, steps=10, batch_size=0
+        )
+
+
 def test_inputs_are_not_mutated(ASE_prior_model):
     data_dictionary = ASE_prior_model()
     model = data_dictionary["model"]


### PR DESCRIPTION
# PR Checklist

- [] Bug fix
- [x] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

Adds two features to minimize_energy in minimizer.py:
- batch_size: splits configurations into chunks of at most this size, relaxing each independently and concatenating results lowers peak memory at the cost of more, smaller forward passes. None (default) keeps the original single-batch behavior. Convergence warnings are now scoped per chunk.
- Flat free_atoms: accepts a single flat index list (applied to every configuration) in addition to the existing per-structure list-of-lists.
Both are backward compatible; existing callers are unaffected.

Tests
Added in test_minimizer.py: flat vs. per-structure free_atoms equivalence, and chunked vs. unchunked batch_size result parity.